### PR TITLE
Do not pin dependency versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,14 @@ and committed to the git repo using:
 Changes to style rules should be made to the Sass files, compiled to CSS,
 and committed to the git repository.
 
+Package Requirements
+--------------------
+
+setup.py contains a list of package dependencies which are required for this XBlock package.
+This list is what is used to resolve dependencies when an upstream project is consuming
+this XBlock package. requirements.txt is used to install the same dependencies when running
+the tests for this package.
+
 License
 -------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-lxml==3.4.4
-bleach==1.4.2
-oauthlib==1.0.3
-mako==1.0.2
-git+https://github.com/edx/XBlock.git@xblock-0.4.1#egg=XBlock==0.4.1
+lxml
+bleach
+oauthlib
+mako
+git+https://github.com/edx/XBlock.git#egg=XBlock
 git+https://github.com/edx/xblock-utils.git@v1.0.0#egg=xblock-utils==v1.0.0
 -e .

--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,12 @@ setup(
         'lti_consumer',
     ],
     install_requires=[
-        'lxml==3.4.4',
-        'bleach==1.4.2',
-        'oauthlib==1.0.3',
-        'mako==1.0.2',
-        'XBlock==0.4.1',
-        'xblock-utils==v1.0.0',
+        'lxml',
+        'bleach',
+        'oauthlib',
+        'mako',
+        'XBlock',
+        'xblock-utils>=v1.0.0',
     ],
     dependency_links=[
         'https://github.com/edx/xblock-utils/tarball/c39bf653e4f27fb3798662ef64cde99f57603f79#egg=xblock-utils',


### PR DESCRIPTION
This prevents us from running into conflicts with the installed requirements in edx-platform. I think we only want to call out a version when we know we need a specific version. Specifically, oauthlib==1.0.3 was conflicting with the version (oauthlib==0.7.2) that edx-platform installs.