### PR TITLE
TNL-4046 Fix due date comparison bug

### DIFF
--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -56,9 +56,10 @@ import re
 import json
 import urllib
 
-from datetime import datetime
 from collections import namedtuple
 from webob import Response
+
+from django.utils import timezone
 
 from xblock.core import String, Scope, List, XBlock
 from xblock.fields import Boolean, Float, Integer
@@ -597,7 +598,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             close_date = due_date + self.graceperiod  # pylint: disable=no-member
         else:
             close_date = due_date
-        return close_date is not None and datetime.utcnow() > close_date
+        return close_date is not None and timezone.now() > close_date
 
     def student_view(self, context):
         """

--- a/lti_consumer/tests/unit/test_lti_consumer.py
+++ b/lti_consumer/tests/unit/test_lti_consumer.py
@@ -4,8 +4,10 @@ Unit tests for LtiConsumerXBlock
 
 import unittest
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from mock import Mock, PropertyMock, patch
+
+from django.utils import timezone
 
 from lti_consumer.tests.unit.test_utils import FAKE_USER_ID, make_xblock, make_request
 
@@ -206,7 +208,7 @@ class TestProperties(TestLtiConsumerXBlock):
         """
         Test `is_past_due` when a graceperiod has been defined
         """
-        now = datetime.utcnow()
+        now = timezone.now()
         self.xblock.graceperiod = timedelta(days=1)
 
         self.xblock.due = now
@@ -219,7 +221,7 @@ class TestProperties(TestLtiConsumerXBlock):
         """
         Test `is_past_due` when no graceperiod has been defined
         """
-        now = datetime.utcnow()
+        now = timezone.now()
         self.xblock.graceperiod = None
 
         self.xblock.due = now - timedelta(days=1)
@@ -227,6 +229,19 @@ class TestProperties(TestLtiConsumerXBlock):
 
         self.xblock.due = now + timedelta(days=1)
         self.assertFalse(self.xblock.is_past_due)
+
+    @patch('lti_consumer.lti_consumer.timezone.now')
+    def test_is_past_due_timezone_now_called(self, mock_timezone_now):
+        """
+        Test `is_past_due` calls django.utils.timezone.now to get current datetime
+        """
+        now = timezone.now()
+        self.xblock.graceperiod = None
+        self.xblock.due = now
+        mock_timezone_now.return_value = now
+
+        __ = self.xblock.is_past_due
+        self.assertTrue(mock_timezone_now.called)
 
 
 class TestStudentView(TestLtiConsumerXBlock):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='lti_consumer-xblock',
-    version='1.0.1',
+    version='1.0.2',
     description='This XBlock implements the consumer side of the LTI specification.',
     packages=[
         'lti_consumer',


### PR DESCRIPTION
Use django.utils.timezone.now() when determining if the due date of a component has passed to avoid tz-aware/naive datetime comparison stacktrace.

Related PR:
https://github.com/edx/edx-platform/pull/11270