### PR TITLE
Visual styling for LTI external button

### DIFF
--- a/lti_consumer/static/sass/student.scss
+++ b/lti_consumer/static/sass/student.scss
@@ -21,7 +21,8 @@
 
             .lti-link {
                 margin-bottom: 0;
-                text-align: right;
+                margin-top: 20px;
+                text-align: left;
 
                 button {
                     font-size: 13px;


### PR DESCRIPTION
*Goal*
Adjusts the external resource button to be left aligned and visually separated from the supporting LTI text description. 

*Current*
![image](https://cloud.githubusercontent.com/assets/2023680/14800480/f7ece4de-0b0f-11e6-8646-a3cff2a3863a.png)

*After Changes*
![image](https://cloud.githubusercontent.com/assets/2023680/14800455/d7dc1958-0b0f-11e6-9137-019ab2193487.png)

Note -
There is still separate work necessary to have this button use the correct base (new) edx-platform button styles, but that can be a separate edx-platform PR that adjusts the following area of styles: https://github.com/edx/edx-platform/blob/76b8e2e89761c30ac7aa2fa5e8aca4dc35d9002b/common/lib/xmodule/xmodule/css/lti/lti.scss

Review: @douglashall 
FYI - @scottrish - This doesn't address all of the changes we've talked about but it was a quick PR to get part of the way there. 