### PR TITLE
(WIP) layout adjustments to improve rendering of elements in the LTI block

### DIFF
--- a/lti_consumer/static/sass/student.scss
+++ b/lti_consumer/static/sass/student.scss
@@ -16,8 +16,7 @@
 
         .wrapper-lti-link {
             font-size: 14px;
-            background-color: #f6f6f6;
-            padding: 20px;
+            background-color: #ffffff;
 
             .lti-link {
                 margin-bottom: 0;
@@ -28,6 +27,11 @@
                     font-size: 13px;
                     line-height: 20.72px;
                 }
+            }
+
+            .lti-description {
+                display: inline-block;
+                margin-left: 20px; 
             }
         }
 

--- a/lti_consumer/templates/html/student.html
+++ b/lti_consumer/templates/html/student.html
@@ -1,6 +1,7 @@
 <h2 class="problem-header">
     ## Translators:  "External resource" means that this learning module is hosted on a platform external to the edX LMS
-    ${display_name} (External resource)
+    ${display_name}
+    <span class="sr">This is an external resource</span>
 </h2>
 
 % if has_score and weight:
@@ -23,9 +24,6 @@
 % if launch_url and not hide_launch:
     % if launch_target in ['modal', 'new_window']:
         <section class="wrapper-lti-link">
-            % if description:
-                <div class="lti-description">${description}</div>
-            % endif
             <p class="lti-link external">
                 % if launch_target == 'modal':
                     <button
@@ -43,6 +41,9 @@
                     </button>
                 % endif
             </p>
+            % if description:
+                <div class="lti-description">${description}</div>
+            % endif
         </section>
     % endif
     % if launch_target == 'modal':


### PR DESCRIPTION
Goal:
Update visual layout for LTI blocks to simplify the learner experience.

Details:
* External Resource label is applied as a screenreader only text.
*  Visual background is shifted to be white
* Button renders first before optional description
* Not setting a title will have no header in the top (is this ok for a11y reasons? might need to be reviewed.) 


Current: 
![image](https://cloud.githubusercontent.com/assets/2023680/15123210/bbce10f4-15f0-11e6-9d85-18b7329f5e80.png)


Changes:
![image](https://cloud.githubusercontent.com/assets/2023680/15123174/71bf7962-15f0-11e6-8f87-064e094dbcb7.png)
