### PR TITLE
Transmit launch_presentation_locale parameter

### DIFF
--- a/lti_consumer/lti.py
+++ b/lti_consumer/lti.py
@@ -143,19 +143,23 @@ class LtiConsumer(object):
 
         self.xblock.user_email = ""
         self.xblock.user_username = ""
+        self.xblock.user_language = ""
 
-        # Username and email can't be sent in studio mode, because the user object is not defined.
+        # Username, email, and language can't be sent in studio mode, because the user object is not defined.
         # To test functionality test in LMS
 
         if callable(self.xblock.runtime.get_real_user):
             real_user_object = self.xblock.runtime.get_real_user(self.xblock.runtime.anonymous_student_id)
             self.xblock.user_email = getattr(real_user_object, "email", "")
             self.xblock.user_username = getattr(real_user_object, "username", "")
+            self.xblock.user_language = getattr(getattr(real_user_object, "profile", ""), "language", "")
 
         if self.xblock.ask_to_send_username and self.xblock.user_username:
             lti_parameters["lis_person_sourcedid"] = self.xblock.user_username
         if self.xblock.ask_to_send_email and self.xblock.user_email:
             lti_parameters["lis_person_contact_email_primary"] = self.xblock.user_email
+        if self.xblock.user_language:
+            lti_parameters["launch_presentation_locale"] = self.xblock.user_language
 
         # Appending custom parameter for signing.
         lti_parameters.update(self.xblock.prefixed_custom_parameters)

--- a/lti_consumer/tests/unit/test_lti.py
+++ b/lti_consumer/tests/unit/test_lti.py
@@ -168,6 +168,7 @@ class TestLtiConsumer(TestLtiConsumerXBlock):
             u'custom_component_graceperiod': str(self.lti_consumer.xblock.graceperiod.total_seconds()),
             'lis_person_sourcedid': 'edx',
             'lis_person_contact_email_primary': 'edx@example.com',
+            'launch_presentation_locale': 'en',
             u'custom_param_1': 'custom1',
             u'custom_param_2': 'custom2',
             u'oauth_nonce': 'fake_nonce',
@@ -181,14 +182,19 @@ class TestLtiConsumer(TestLtiConsumerXBlock):
         self.lti_consumer.xblock.ask_to_send_username = True
         self.lti_consumer.xblock.ask_to_send_email = True
 
-        self.lti_consumer.xblock.runtime.get_real_user.return_value = Mock(email='edx@example.com', username='edx')
+        self.lti_consumer.xblock.runtime.get_real_user.return_value = Mock(
+            email='edx@example.com',
+            username='edx',
+            profile=Mock(language='en')
+        )
         self.assertEqual(self.lti_consumer.get_signed_lti_parameters(), expected_lti_parameters)
 
-        # Test that `lis_person_sourcedid` and `lis_person_contact_email_primary` are not included
-        # in the returned LTI parameters when a user cannot be found
+        # Test that `lis_person_sourcedid`, `lis_person_contact_email_primary`, and `launch_presentation_locale`
+        # are not included in the returned LTI parameters when a user cannot be found
         self.lti_consumer.xblock.runtime.get_real_user.return_value = {}
         del expected_lti_parameters['lis_person_sourcedid']
         del expected_lti_parameters['lis_person_contact_email_primary']
+        del expected_lti_parameters['launch_presentation_locale']
         self.assertEqual(self.lti_consumer.get_signed_lti_parameters(), expected_lti_parameters)
 
     def test_get_result(self):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='lti_consumer-xblock',
-    version='1.0.6',
+    version='1.0.7',
     description='This XBlock implements the consumer side of the LTI specification.',
     packages=[
         'lti_consumer',


### PR DESCRIPTION
This is related to [LOC-78](https://openedx.atlassian.net/browse/LOC-78).

When using the edX LMS as a frontend for other LTI modules, this change enables us to transmit the user's preferred language setting (if present) as part of the POST request to set the iframe up.

If the user doesn't have a language set on their profile, or if they don't have an edX LMS profile set up, we won't transmit locale preferences, and the behavior will remain the same.

This PR is covered by the OpenCraft contributor agreement - thanks @antoviaque!