### PR TITLE
Revert "Fixing problems with #16's use of launch_presentation_locale"

### DIFF
--- a/lti_consumer/lti.py
+++ b/lti_consumer/lti.py
@@ -152,14 +152,7 @@ class LtiConsumer(object):
             real_user_object = self.xblock.runtime.get_real_user(self.xblock.runtime.anonymous_student_id)
             self.xblock.user_email = getattr(real_user_object, "email", "")
             self.xblock.user_username = getattr(real_user_object, "username", "")
-            user_profile = getattr(real_user_object, "profile", None)
-            if user_profile is not None:
-                language_proficiencies = user_profile.language_proficiencies.all()
-                if len(language_proficiencies) == 1:
-                    # We only want to send the user's language preference if the user has
-                    # a single preferred language - having multiple language proficiencies
-                    # isn't an API violation, but can't be set up via the UI.
-                    self.xblock.user_language = language_proficiencies[0].code
+            self.xblock.user_language = getattr(getattr(real_user_object, "profile", ""), "language", "")
 
         if self.xblock.ask_to_send_username and self.xblock.user_username:
             lti_parameters["lis_person_sourcedid"] = self.xblock.user_username

--- a/lti_consumer/tests/unit/test_lti.py
+++ b/lti_consumer/tests/unit/test_lti.py
@@ -185,7 +185,7 @@ class TestLtiConsumer(TestLtiConsumerXBlock):
         self.lti_consumer.xblock.runtime.get_real_user.return_value = Mock(
             email='edx@example.com',
             username='edx',
-            profile=Mock(language_proficiencies=Mock(all=Mock(return_value=[Mock(code='en')])))
+            profile=Mock(language='en')
         )
         self.assertEqual(self.lti_consumer.get_signed_lti_parameters(), expected_lti_parameters)
 
@@ -195,20 +195,6 @@ class TestLtiConsumer(TestLtiConsumerXBlock):
         del expected_lti_parameters['lis_person_sourcedid']
         del expected_lti_parameters['lis_person_contact_email_primary']
         del expected_lti_parameters['launch_presentation_locale']
-        self.assertEqual(self.lti_consumer.get_signed_lti_parameters(), expected_lti_parameters)
-
-        # Test that we don't send a language when no preferred language exists
-        self.lti_consumer.xblock.runtime.get_real_user.return_value = Mock(
-            spec=['profile'],
-            profile=Mock(language_proficiencies=Mock(all=Mock(return_value=[])))
-        )
-        self.assertEqual(self.lti_consumer.get_signed_lti_parameters(), expected_lti_parameters)
-
-        # Test that we don't send a language when multiple preferred languages exist
-        self.lti_consumer.xblock.runtime.get_real_user.return_value = Mock(
-            spec=['profile'],
-            profile=Mock(language_proficiencies=Mock(all=Mock(return_value=[Mock(code='es'), Mock(code='en')])))
-        )
         self.assertEqual(self.lti_consumer.get_signed_lti_parameters(), expected_lti_parameters)
 
     def test_get_result(self):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='lti_consumer-xblock',
-    version='1.0.8',
+    version='1.0.7',
     description='This XBlock implements the consumer side of the LTI specification.',
     packages=[
         'lti_consumer',


### PR DESCRIPTION
Reverts edx/xblock-lti-consumer#17

Sorry @haikuginger, I tested this after I merged and it was still not working. Turns out I was wrong about where we store the user's preferred language. The `openedx.core.djangoapps.user_api.models.UserPreference` is what we were looking for. You should be able to get the list of user preferences from the user object and filter by `key=pref-lang`. There should only ever be one UserPreference model with the key field set to pref-lang.

Please give this a manual test on your end next time.