### PR TITLE
Fixing launch_presentation_locale (promise!); updating to v1.0.9

### DIFF
--- a/lti_consumer/lti.py
+++ b/lti_consumer/lti.py
@@ -152,7 +152,12 @@ class LtiConsumer(object):
             real_user_object = self.xblock.runtime.get_real_user(self.xblock.runtime.anonymous_student_id)
             self.xblock.user_email = getattr(real_user_object, "email", "")
             self.xblock.user_username = getattr(real_user_object, "username", "")
-            self.xblock.user_language = getattr(getattr(real_user_object, "profile", ""), "language", "")
+            user_preferences = getattr(real_user_object, "preferences", None)
+
+            if user_preferences is not None:
+                language_preference = user_preferences.filter(key='pref-lang')
+                if len(language_preference) == 1:
+                    self.xblock.user_language = language_preference[0].value
 
         if self.xblock.ask_to_send_username and self.xblock.user_username:
             lti_parameters["lis_person_sourcedid"] = self.xblock.user_username

--- a/lti_consumer/tests/unit/test_lti.py
+++ b/lti_consumer/tests/unit/test_lti.py
@@ -181,11 +181,10 @@ class TestLtiConsumer(TestLtiConsumerXBlock):
         self.lti_consumer.xblock.has_score = True
         self.lti_consumer.xblock.ask_to_send_username = True
         self.lti_consumer.xblock.ask_to_send_email = True
-
         self.lti_consumer.xblock.runtime.get_real_user.return_value = Mock(
             email='edx@example.com',
             username='edx',
-            profile=Mock(language='en')
+            preferences=Mock(filter=Mock(return_value=[Mock(value='en')]))
         )
         self.assertEqual(self.lti_consumer.get_signed_lti_parameters(), expected_lti_parameters)
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='lti_consumer-xblock',
-    version='1.0.7',
+    version='1.0.9',
     description='This XBlock implements the consumer side of the LTI specification.',
     packages=[
         'lti_consumer',


### PR DESCRIPTION
@douglashall - I've updated the code and done manual testing to confirm that the `launch_presentation_locale` parameter is now being passed correctly per our conversation in #18 - sorry for the delay.

I used httpbin.org/post as the LTI target - that let me peek into the request parameters without needing to do any request sniffing.

![screen shot](https://cloud.githubusercontent.com/assets/7773758/15847428/c49a48fa-2c53-11e6-95e0-1ffbc0ab3401.png)

