### PR TITLE
Add a compatibility function for get_course_lti_endpoints

### DIFF
--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -563,6 +563,20 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         return self.runtime.handler_url(self, "outcome_service_handler", thirdparty=True).rstrip('/?')
 
     @property
+    def result_service_url(self):
+        """
+        Return URL for results.
+
+        To test LTI on sandbox we must use http scheme.
+
+        While testing locally and on Jenkins, mock_lti_server use http.referer
+        to obtain scheme, so it is ok to have http(s) anyway.
+
+        The scheme logic is handled in lms/lib/xblock/runtime.py
+        """
+        return self.runtime.handler_url(self, "result_service_handler", thirdparty=True).rstrip('/?')
+
+    @property
     def prefixed_custom_parameters(self):
         """
         Apply prefix to configured custom LTI parameters
@@ -860,3 +874,17 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             float: The css position offset to apply to the modal window
         """
         return (100 - viewport_percentage) / 2
+
+    def get_outcome_service_url(self, service_name="grade_handler"):
+        """
+        This function is called by get_course_lti_endpoints when using LTI result service to
+        discover the LTI result endpoints.
+        """
+
+        # using string as mapped value instead of attributes to avoid unnecessary calls as both urls
+        # are @property.
+        mapping = {
+            'grade_handler': 'outcome_service_url',
+            'lti_2_0_result_rest_handler': 'result_service_url'
+        }
+        return getattr(self, mapping[service_name])

--- a/lti_consumer/tests/unit/test_lti_consumer.py
+++ b/lti_consumer/tests/unit/test_lti_consumer.py
@@ -185,6 +185,17 @@ class TestProperties(TestLtiConsumerXBlock):
         self.xblock.runtime.handler_url.assert_called_with(self.xblock, 'outcome_service_handler', thirdparty=True)
         self.assertEqual(url, handler_url)
 
+    def test_result_service_url(self):
+        """
+        Test `result_service_url` calls `runtime.handler_url` with thirdparty kwarg
+        """
+        handler_url = 'http://localhost:8005/result_service_handler'
+        self.xblock.runtime.handler_url = Mock(return_value="{}/?".format(handler_url))
+        url = self.xblock.result_service_url
+
+        self.xblock.runtime.handler_url.assert_called_with(self.xblock, 'result_service_handler', thirdparty=True)
+        self.assertEqual(url, handler_url)
+
     def test_prefixed_custom_parameters(self):
         """
         Test `prefixed_custom_parameters` appropriately prefixes the configured custom params
@@ -527,6 +538,39 @@ class TestResultServiceHandler(TestLtiConsumerXBlock):
 
         assert mock_delete_result.called
         self.assertEqual(response.status_code, 200)
+
+    def test_get_outcome_service_url_with_default_parameter(self):
+        """
+        Test `get_outcome_service_url` with default parameter
+        """
+        handler_url = 'http://localhost:8005/outcome_service_handler'
+        self.xblock.runtime.handler_url = Mock(return_value="{}/?".format(handler_url))
+        url = self.xblock.get_outcome_service_url()
+
+        self.xblock.runtime.handler_url.assert_called_with(self.xblock, 'outcome_service_handler', thirdparty=True)
+        self.assertEqual(url, handler_url)
+
+    def test_get_outcome_service_url_with_service_name_grade_handler(self):
+        """
+        Test `get_outcome_service_url` calls service name grade_handler
+        """
+        handler_url = 'http://localhost:8005/outcome_service_handler'
+        self.xblock.runtime.handler_url = Mock(return_value="{}/?".format(handler_url))
+        url = self.xblock.get_outcome_service_url('grade_handler')
+
+        self.xblock.runtime.handler_url.assert_called_with(self.xblock, 'outcome_service_handler', thirdparty=True)
+        self.assertEqual(url, handler_url)
+
+    def test_get_outcome_service_url_with_service_name_lti_2_0_result_rest_handler(self):
+        """
+        Test `get_outcome_service_url` calls with service name lti_2_0_result_rest_handler
+        """
+        handler_url = 'http://localhost:8005/result_service_handler'
+        self.xblock.runtime.handler_url = Mock(return_value="{}/?".format(handler_url))
+        url = self.xblock.get_outcome_service_url('lti_2_0_result_rest_handler')
+
+        self.xblock.runtime.handler_url.assert_called_with(self.xblock, 'result_service_handler', thirdparty=True)
+        self.assertEqual(url, handler_url)
 
 
 class TestMaxScore(TestLtiConsumerXBlock):


### PR DESCRIPTION
This allows this xblock being hooked into get_course_lti_endpoints for
discovering LTI result/outcome endpoints.

**Background**: The old xmodule supports enumerates LTI endpoints so that they can be discovered and consumed by external tools. However, this functionality is missing when xmodule was refactored into xblock. Currently, only the old LTI xmodules can be discovered when /courses/COURSE_ID/lti_rest_endpoints/ is called. 

**Testing**:
- Create an LTI consumer component by following instructions here: http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html 
- Access htts://LMS_URL/courses/COURSE_ID/lti_rest_endpoints/

The endpoints for LTI component should be listed in JSON format.   

This PR is needed by https://github.com/edx/edx-platform/pull/13639 to enable the endpoints to query both old xmodules and new xblocks.
