### PR TITLE
Add workaround for Firefox focus issues.

### DIFF
--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -46,7 +46,10 @@ function LtiConsumerXBlock(runtime, element) {
                         $(o.closeButton).on('keydown', function (e) {
                            if (e.which === 9) {
                                e.preventDefault();
-                               $(modal_id).find('iframe')[0].contentWindow.focus();
+                               // This is a workaround due to Firefox triggering focus calls oddly.
+                               setTimeout(function () {
+                                   $modal.find('iframe')[0].contentWindow.focus();
+                               }, 1);
                            }
                         });
 


### PR DESCRIPTION
## [TNL-5494](https://openedx.atlassian.net/browse/TNL-5494)

### Description

There was some timing issues with dealing with keyboard navigation for LTI consumers using modal iframes on Firefox.

Based on [an answer on Stack Overflow](http://stackoverflow.com/questions/7046798/jquery-focus-fails-on-firefox) this is a solution that works on Firefox without breaking Chrome support.

### Sandbox
- [x] https://dianakhuang.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/9fca584977d04885bc911ea76a9ef29e/0b092f03d2a044fe892e0b1885903ec6/

Note: the iframed in LTI component doesn't work, but it should provide a real enough webpage for testing navigation. This should be tested in Firefox specifically. 

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @alisan617 
- [x] Accessibility review: @cptvitamin 

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [ ] Rebase and squash commits