### PR TITLE
TNL-6688 – Control editing of request username/email fields from studio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python: "2.7"
 install:
+  - "pip install six"
   - "make install"
 sudo: false
 script:

--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -164,6 +164,7 @@ class LaunchTarget(object):
 
 
 @XBlock.needs('i18n')
+@XBlock.wants('lti-configuration')
 class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     """
     This XBlock provides an LTI consumer interface for integrating
@@ -421,17 +422,42 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         scope=Scope.settings
     )
 
-    # StudioEditableXBlockMixin configuration of fields editable in Studio
-    editable_fields = (
-        'display_name', 'description', 'lti_id', 'launch_url', 'custom_parameters', 'launch_target', 'button_text',
-        'inline_height', 'modal_height', 'modal_width', 'has_score', 'weight', 'hide_launch', 'accept_grades_past_due',
-        'ask_to_send_username', 'ask_to_send_email'
+    # Possible editable fields
+    editable_field_names = (
+        'display_name', 'description', 'lti_id', 'launch_url', 'custom_parameters',
+        'launch_target', 'button_text', 'inline_height', 'modal_height', 'modal_width',
+        'has_score', 'weight', 'hide_launch', 'accept_grades_past_due', 'ask_to_send_username',
+        'ask_to_send_email'
     )
 
     def validate_field_data(self, validation, data):
         if not isinstance(data.custom_parameters, list):
             _ = self.runtime.service(self, "i18n").ugettext
             validation.add(ValidationMessage(ValidationMessage.ERROR, unicode(_("Custom Parameters must be a list"))))
+
+    @property
+    def editable_fields(self):
+        """
+        Returns editable fields which may/may not contain 'ask_to_send_username' and
+        'ask_to_send_email' fields depending on the configuration service.
+        """
+        editable_fields = self.editable_field_names
+        # update the editable fields if this XBlock is configured to not to allow the
+        # editing of 'ask_to_send_username' and 'ask_to_send_email'.
+        config_service = self.runtime.service(self, 'lti-configuration')
+        if config_service:
+            is_already_sharing_learner_info = self.ask_to_send_email or self.ask_to_send_username
+            if not config_service.configuration.lti_access_to_learners_editable(
+                    self.course_id,
+                    is_already_sharing_learner_info,
+            ):
+                editable_fields = tuple(
+                    field
+                    for field in self.editable_field_names
+                    if field not in ('ask_to_send_username', 'ask_to_send_email')
+                )
+
+        return editable_fields
 
     @property
     def descriptor(self):

--- a/lti_consumer/tests/unit/test_lti_consumer.py
+++ b/lti_consumer/tests/unit/test_lti_consumer.py
@@ -263,6 +263,64 @@ class TestProperties(TestLtiConsumerXBlock):
         self.assertTrue(mock_timezone_now.called)
 
 
+class TestEditableFields(TestLtiConsumerXBlock):
+    """
+    Unit tests for LtiConsumerXBlock.editable_fields
+    """
+    def get_mock_lti_configuration(self, editable):
+        """
+        Returns a mock object of lti-configuration service
+
+        Arguments:
+            editable (bool): This indicates whether the LTI fields (i.e. 'ask_to_send_username' and
+            'ask_to_send_email') are editable.
+        """
+        lti_configuration = Mock()
+        lti_configuration.configuration = Mock()
+        lti_configuration.configuration.lti_access_to_learners_editable = Mock(
+            return_value=editable
+        )
+        return lti_configuration
+
+    def are_fields_editable(self, fields):
+        """
+        Returns whether the fields passed in as an argument, are editable.
+
+        Arguments:
+            fields (list): list containing LTI Consumer XBlock's field names.
+        """
+        return all(field in self.xblock.editable_fields for field in fields)
+
+    def test_editable_fields_with_no_config(self):
+        """
+        Test that LTI XBlock's fields (i.e. 'ask_to_send_username' and 'ask_to_send_email')
+        are editable when lti-configuration service is not provided.
+        """
+        self.xblock.runtime.service.return_value = None
+        # Assert that 'ask_to_send_username' and 'ask_to_send_email' are editable.
+        self.assertTrue(self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_email']))
+
+    def test_editable_fields_when_editing_allowed(self):
+        """
+        Test that LTI XBlock's fields (i.e. 'ask_to_send_username' and 'ask_to_send_email')
+        are editable when this XBlock is configured to allow it.
+        """
+        # this XBlock is configured to allow editing of LTI fields
+        self.xblock.runtime.service.return_value = self.get_mock_lti_configuration(editable=True)
+        # Assert that 'ask_to_send_username' and 'ask_to_send_email' are editable.
+        self.assertTrue(self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_email']))
+
+    def test_editable_fields_when_editing_not_allowed(self):
+        """
+        Test that LTI XBlock's fields (i.e. 'ask_to_send_username' and 'ask_to_send_email')
+        are not editable when this XBlock is configured to not to allow it.
+        """
+        # this XBlock is configured to not to allow editing of LTI fields
+        self.xblock.runtime.service.return_value = self.get_mock_lti_configuration(editable=False)
+        # Assert that 'ask_to_send_username' and 'ask_to_send_email' are not editable.
+        self.assertFalse(self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_email']))
+
+
 class TestStudentView(TestLtiConsumerXBlock):
     """
     Unit tests for LtiConsumerXBlock.student_view()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='lti_consumer-xblock',
-    version='1.1.2',
+    version='1.1.3',
     description='This XBlock implements the consumer side of the LTI specification.',
     packages=[
         'lti_consumer',


### PR DESCRIPTION
## [TNL-6688](https://openedx.atlassian.net/browse/TNL-6688)

### Description
Platform wants to control the editing the LTI fields from the studio for the course teams.
This PR does it by checking the configuration coming from the platform and decide if the editing of request username/email fields should be disabled or not.

### Sandbox
- [x] https://studio-tnl-6688-lti-config.sandbox.edx.org/home/

### Testing
- [x] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @muhammad-ammar 
- [x] Code review: @muzaffaryousaf 

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [ ] Rebase and squash commits