### PR TITLE
Fix the rebind exception when calling get_result

### DIFF
--- a/lti_consumer/lti.py
+++ b/lti_consumer/lti.py
@@ -206,7 +206,7 @@ class LtiConsumer(object):
         Returns:
             webob.response:  response to this request, in JSON format with status 200 if success
         """
-        self.xblock.runtime.rebind_noauth_module_to_user(self, user)
+        self.xblock.runtime.rebind_noauth_module_to_user(self.xblock, user)
 
         response = {
             "@context": "http://purl.imsglobal.org/ctx/lis/v2/Result",


### PR DESCRIPTION
The module used for rebind was set to LtiConsumer instead of the xblock, which is wrong and causing an silent exception thrown and return 404 to the client without any indication of the cause.

To test it, follow the instruction here: https://github.com/edx/edx-tools/tree/master/lti/grades to setup a LtiConsumer and run the script to upload grade to a course. The script will failed at `_validate_lti_passport` because the silent exception thrown in `get_result` and 404 returned.

This is a critical issue because it crashes when someone uses LTI outcome service to retrieve the grade from the consumer.