### PR TITLE
Adding additional LTI parameters to be sent

### DIFF
--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -407,6 +407,13 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     # Users will be presented with a message indicating that their e-mail/username would be sent to a third
     # party application. When "Open in New Page" is not selected, the tool automatically appears without any
     # user action.
+    ask_permission_to_send = Boolean(
+        display_name=_("Enable permission pop-up"),
+        # Translators: This is used to request the user's permission to share information with a third party service.
+        help=_("Select True to show pop-up asking user to allow information sharing when launched in new window."),
+        default=True,
+        scope=Scope.settings
+    )
     ask_to_send_username = Boolean(
         display_name=_("Request user's username"),
         # Translators: This is used to request the user's username for a third party service.
@@ -421,13 +428,35 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         default=False,
         scope=Scope.settings
     )
+    ask_to_send_first_name = Boolean(
+        display_name=_("Request user's first name"),
+        # Translators: This is used to request the user's first name for a third party service.
+        help=_("Select True to request the user's first name."),
+        default=False,
+        scope=Scope.settings
+    )
+    ask_to_send_last_name = Boolean(
+        display_name=_("Request user's last name"),
+        # Translators: This is used to request the user's last name for a third party service.
+        help=_("Select True to request the user's last name."),
+        default=False,
+        scope=Scope.settings
+    )
+    ask_to_send_full_name = Boolean(
+        display_name=_("Request user's full name"),
+        # Translators: This is used to request the user's full name for a third party service.
+        help=_("Select True to request the user's full name."),
+        default=False,
+        scope=Scope.settings
+    )
 
     # Possible editable fields
     editable_field_names = (
         'display_name', 'description', 'lti_id', 'launch_url', 'custom_parameters',
         'launch_target', 'button_text', 'inline_height', 'modal_height', 'modal_width',
-        'has_score', 'weight', 'hide_launch', 'accept_grades_past_due', 'ask_to_send_username',
-        'ask_to_send_email'
+        'has_score', 'weight', 'hide_launch', 'accept_grades_past_due', 'ask_permission_to_send',
+        'ask_to_send_username', 'ask_to_send_email', 'ask_to_send_first_name', 'ask_to_send_last_name',
+        'ask_to_send_full_name'
     )
 
     def validate_field_data(self, validation, data):
@@ -877,8 +906,12 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'module_score': self.module_score,
             'comment': sanitized_comment,
             'description': self.description,
+            'ask_permission_to_send': self.ask_permission_to_send,
             'ask_to_send_username': self.ask_to_send_username,
             'ask_to_send_email': self.ask_to_send_email,
+            'ask_to_send_first_name': self.ask_to_send_first_name,
+            'ask_to_send_last_name': self.ask_to_send_last_name,
+            'ask_to_send_full_name': self.ask_to_send_full_name,
             'button_text': self.button_text,
             'inline_height': self.inline_height,
             'modal_vertical_offset': self._get_modal_position_offset(self.modal_height),

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -76,6 +76,7 @@ function LtiConsumerXBlock(runtime, element) {
 
         var $element = $(element);
         var $ltiContainer = $element.find('.lti-consumer-container');
+        var askPermissionToSend = $ltiContainer.data('ask-permission-to-send') == 'True';
         var askToSendUsername = $ltiContainer.data('ask-to-send-username') == 'True';
         var askToSendEmail = $ltiContainer.data('ask-to-send-email') == 'True';
 
@@ -88,12 +89,14 @@ function LtiConsumerXBlock(runtime, element) {
 
             // If this instance is configured to require username and/or email, ask user if it is okay to send them
             // Do not launch if it is not okay
-            if(askToSendUsername && askToSendEmail) {
-                launch = confirm(gettext("Click OK to have your username and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
-            } else if (askToSendUsername) {
-                launch = confirm(gettext("Click OK to have your username sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
-            } else if (askToSendEmail) {
-                launch = confirm(gettext("Click OK to have your e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+            if(askPermissionToSend){
+                if(askToSendUsername && askToSendEmail) {
+                    launch = confirm(gettext("Click OK to have your username and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+                } else if (askToSendUsername) {
+                    launch = confirm(gettext("Click OK to have your username sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+                } else if (askToSendEmail) {
+                    launch = confirm(gettext("Click OK to have your e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+                }
             }
 
             if (launch) {

--- a/lti_consumer/templates/html/student.html
+++ b/lti_consumer/templates/html/student.html
@@ -16,6 +16,7 @@
 <div
     id="${element_id}"
     class="${element_class} lti-consumer-container"
+    data-ask-permission-to-send="${ask_permission_to_send}"
     data-ask-to-send-username="${ask_to_send_username}"
     data-ask-to-send-email="${ask_to_send_email}"
 >

--- a/lti_consumer/tests/unit/test_lti_consumer.py
+++ b/lti_consumer/tests/unit/test_lti_consumer.py
@@ -780,9 +780,10 @@ class TestGetContext(TestLtiConsumerXBlock):
         """
         context_keys = (
             'launch_url', 'element_id', 'element_class', 'launch_target', 'display_name', 'form_url', 'hide_launch',
-            'has_score', 'weight', 'module_score', 'comment', 'description', 'ask_to_send_username',
-            'ask_to_send_email', 'button_text', 'modal_vertical_offset', 'modal_horizontal_offset', 'modal_width',
-            'accept_grades_past_due'
+            'has_score', 'weight', 'module_score', 'comment', 'description', 'ask_permission_to_send',
+            'ask_to_send_username', 'ask_to_send_email', 'ask_to_send_first_name', 'ask_to_send_last_name',
+            'ask_to_send_full_name', 'button_text', 'modal_vertical_offset', 'modal_horizontal_offset',
+            'modal_width', 'accept_grades_past_due'
         )
         context = self.xblock._get_context_for_template()  # pylint: disable=protected-access
 


### PR DESCRIPTION
This commit adds addition fields to LTI parameters such as 'lis_person_name_given', 'lis_person_name_family', 'lis_person_name_full' and 'custom_user_id' which represents actual edX user id. This commit also adds Boolean flag 'ask_permission_to_send' which, if set to True, enables permission pop-up that asks user to allow information sharing with third party authentication.