### PR TITLE
make system tolerant of ascii strings with unicode characters

### DIFF
--- a/lti_consumer/outcomes.py
+++ b/lti_consumer/outcomes.py
@@ -40,7 +40,7 @@ def parse_grade_xml_body(body):
     """
     lti_spec_namespace = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0"
     namespaces = {'def': lti_spec_namespace}
-    data = body.strip().encode('utf-8')
+    data = body.strip()
 
     try:
         parser = etree.XMLParser(ns_clean=True, recover=True, encoding='utf-8')  # pylint: disable=no-member

--- a/lti_consumer/tests/unit/test_outcomes.py
+++ b/lti_consumer/tests/unit/test_outcomes.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Unit tests for lti_consumer.outcomes module
 """
@@ -287,6 +288,45 @@ class TestParseGradeXmlBody(unittest.TestCase):
         """
         with self.assertRaises(LtiError):
             __, __, __, __ = parse_grade_xml_body('<xml>')
+
+    def test_string_with_unicode_chars(self):
+        """
+        Test that system is tolerant to data which has unicode chars in
+        strings which are not specified as unicode.
+        """
+        request_body_template = textwrap.dedent("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <imsx_POXEnvelopeRequest xmlns="http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
+              <imsx_POXHeader>
+                <imsx_POXRequestHeaderInfo>
+                  <imsx_version>V1.0</imsx_version>
+                  <imsx_messageIdentifier>ţéšţ_message_id</imsx_messageIdentifier>
+                </imsx_POXRequestHeaderInfo>
+              </imsx_POXHeader>
+              <imsx_POXBody>
+                <ţéšţ_action>
+                  <resultRecord>
+                    <sourcedGUID>
+                      <sourcedId>ţéšţ_sourced_id</sourcedId>
+                    </sourcedGUID>
+                    <result>
+                      <resultScore>
+                        <language>en-us</language>
+                        <textString>1.0</textString>
+                      </resultScore>
+                    </result>
+                  </resultRecord>
+                </ţéšţ_action>
+              </imsx_POXBody>
+            </imsx_POXEnvelopeRequest>
+        """)
+
+        msg_id, sourced_id, score, action = parse_grade_xml_body(request_body_template)
+
+        self.assertEqual(msg_id, u'ţéšţ_message_id')
+        self.assertEqual(sourced_id, u'ţéšţ_sourced_id')
+        self.assertEqual(score, 1.0)
+        self.assertEqual(action, u'ţéšţ_action')
 
 
 class TestOutcomeService(TestLtiConsumerXBlock):


### PR DESCRIPTION
## [EDUCATOR-1218](https://openedx.atlassian.net/browse/EDUCATOR-1218)

### Description

In this PR, any non-unicode string is first converted to unicode so it can be encoded successfully in [parse_grade_xml_body](https://github.com/edx/xblock-lti-consumer/blob/master/lti_consumer/outcomes.py#L23).
We need to do this because encoding is failed for strings (not specified as unicode) which have unicode chars. (When not specified as unicode, python 2.7.x use ASCII for encoding, unicode characters can not be encoded using ASCII).

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @attiyaIshaque 
- [x] Code review: @edx/educator-all 
- [x] Code review: @awaisdar001 

### Post-review
- [x] Rebase and squash commits