### PR TITLE
Update iframe allowances for chrome v64

### DIFF
--- a/lti_consumer/templates/html/lti_iframe.html
+++ b/lti_consumer/templates/html/lti_iframe.html
@@ -7,4 +7,5 @@
     allowfullscreen="true"
     webkitallowfullscreen="true"
     mozallowfullscreen="true"
+    allow="microphone *; camera *; midi *; geolocation *; encrypted-media *"
 ></iframe>

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='lti_consumer-xblock',
-    version='1.1.6',
+    version='1.1.7',
     description='This XBlock implements the consumer side of the LTI specification.',
     packages=[
         'lti_consumer',


### PR DESCRIPTION
## [EDUCATOR-2273](https://openedx.atlassian.net/browse/EDUCATOR-2273)

### Description
Due to a chrome update some of our LTI blocks are broken in chrome. See documentation here: https://dev.chromium.org/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @awaisdar001 
- [x] Code review: @efischer19 

FYI: @edx/educator-escalation 

### Post-review
- [x] Rebase and squash commits