### PR TITLE
(WIP) Allow plugins for the LTI XBlock to pass extra parameters to the provider

### DIFF
--- a/lti_consumer/lti.py
+++ b/lti_consumer/lti.py
@@ -170,7 +170,7 @@ class LtiConsumer(object):
 
             self.xblock.team = get_team_name(
                 course_key=self.xblock.context_id,
-                user_id=self.xblock.real_user_id,
+                user=real_user_object,
             )
 
             if user_preferences is not None:

--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -121,6 +121,8 @@ LTI_PARAMETERS = [
     'tool_consumer_instance_contact_email',
     'custom_component_due_date',
     'custom_component_graceperiod',
+    'custom_cohort',
+    'custom_team',
     'custom_component_display_name'
 ]
 

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -22,7 +22,7 @@ def get_cohort_name(course_key, user):
     return cohort.name if cohort else None
 
 
-def get_team_name(course_key, user_id):
+def get_team_name(course_key, user):
     from django.conf import settings
     features = getattr(settings, 'FEATURES', {})
 
@@ -35,7 +35,7 @@ def get_team_name(course_key, user_id):
 
     try:
         membership = CourseTeamMembership.objects.get(
-            user_id=user_id,
+            user=user,
             team__course_id=CourseKey.from_string(course_key),
         )
     except CourseTeamMembership.DoesNotExist:

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -9,3 +9,36 @@ def _(text):
     :return text
     """
     return text
+
+
+def get_cohort_name(course_key, user):
+    try:
+        from openedx.core.djangoapps.course_groups.cohorts import get_cohort
+        from opaque_keys.edx.keys import CourseKey
+    except ImportError:
+        return None
+
+    cohort = get_cohort(course_key=CourseKey.from_string(course_key), user=user)
+    return cohort.name if cohort else None
+
+
+def get_team_name(course_key, user_id):
+    from django.conf import settings
+    features = getattr(settings, 'FEATURES', {})
+
+    if not features.get('ENABLE_TEAMS'):
+        return None
+
+    # No need for handling ImportError, since `ENABLE_TEAMS` is set to True.
+    from lms.djangoapps.teams.models import CourseTeamMembership
+    from opaque_keys.edx.keys import CourseKey
+
+    try:
+        membership = CourseTeamMembership.objects.get(
+            user_id=user_id,
+            team__course_id=CourseKey.from_string(course_key),
+        )
+    except CourseTeamMembership.DoesNotExist:
+        return None
+
+    return membership.team.name


### PR DESCRIPTION
### Overview
Lets the LTI Consumer XBlock have access to the `team` and `cohort` values and pass them to the LTI provider as part of the LTI POST Request.

### Why?
A customer needs those values to be passed through the LTI channel to simplify integration with their LTI provider.

### Timeline
 - Get the critical design and architecture review by Nov 14th, 2018.

### Outstanding Design Questions
 - [ ] There's nothing against having the LTI XBlock pass `custom_cohort` and `custom_team` through the LTI channel, right?
 - [ ] Do we want to add XBlock runtime services for this? (probably not), see the Slack :point_down: 

### Notes
Probably the `lti_consumer/utils.py` should be an XBlock runtime service, but :man_shrugging: 

The discussion has been concluded in [Open edX #architecture Slack](https://openedx.slack.com/archives/C0RU5BTCP/p1541533584041800).

