### PR TITLE
Allow plugins for the LTI XBlock to pass extra parameters to the provider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,75 @@ http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/lat
    tests for this repo running inside an LMS container).  From here, you can see the contents of the
    messages that we are sending as an LTI Consumer in the "Message Parameters" part of the "Message" tab.
 
+Custom LTI Parameters
+---------------------
+This XBlock sends a number of parameters to the provider including some optional parameters. To keep the XBlock
+somewhat minimal, some parameters were omitted like ``lis_person_name_full`` among others.
+At the same time the XBlock allows passing extra parameters to the LTI provider via parameter processor functions.
+
+Defining an LTI Parameter Processors
+====================================
+The parameter processor is a function that expects an XBlock instance, and returns a ``dict`` of
+additional parameters for the LTI.
+If a processor throws an exception, the exception is logged and suppressed.
+If a processor returns ``None`` or any falsy value, no parameters will be added.
+
+.. code:: python
+
+    def team_info(xblock):
+        course = get_team(xblock.user, lti_params.course.id)
+        if not course:
+            return
+
+        return {
+            'custom_course_id': unicode(course.id),
+            'custom_course_name': course.name,
+        }
+
+A processor can define a list of default parameters ``lti_xblock_default_params``,
+which is useful in case the processor had an exception.
+
+It is recommended to define default parameters anyway, because it can simplify the implementation of the processor
+function. Below is an example:
+
+.. code:: python
+
+    def dummy_processor(xblock):
+        course = get_team(xblock.user, lti_params.course.id)  # If something went wrong default params will be used
+        if not course:
+            return  # Will use the default params
+
+        return {
+            'custom_course_id': unicode(course.id),
+            'custom_course_name': course.name,
+        }
+
+    dummy_processor.lti_xblock_default_params = {
+        'custom_course_id': '',
+        'custom_course_name': '',
+    }
+
+If you're looking for a more realistic example, you can check the
+`Tahoe LTI <https://github.com/appsembler/tahoe-lti>`_ repository at the
+`Appsembler GitHub organization <https://github.com/appsembler/>`_.
+
+Configuring the Parameter Processors Settings
+=============================================
+
+Using the standard XBlock settings interface the developer can provide a list of processor functions:
+Those parameters are not sent by default. The course author can enable that on per XBlock instance
+(aka module) by setting the **Send extra parameters** to ``true`` in Studio.
+
+To configure parameter processors add the following snippet to your Ansible variable files:
+
+.. code:: yaml
+
+    EDXAPP_XBLOCK_SETTINGS:
+      lti_consumer:
+        parameter_processors:
+          - 'customer_package.lti_processors:team_and_cohort'
+          - 'example_package.lti_processors:extra_lti_params'
+
 Workbench installation and settings
 -----------------------------------
 

--- a/lti_consumer/lti.py
+++ b/lti_consumer/lti.py
@@ -174,6 +174,16 @@ class LtiConsumer(object):
         # Appending custom parameter for signing.
         lti_parameters.update(self.xblock.prefixed_custom_parameters)
 
+        for processor in self.xblock.get_parameter_processors():
+            try:
+                default_params = getattr(processor, 'lti_xblock_default_params', {})
+                lti_parameters.update(default_params)
+                lti_parameters.update(processor(self.xblock) or {})
+            except Exception:  # pylint: disable=broad-except
+                # Log the error without causing a 500-error.
+                # Useful for catching casual runtime errors in the processors.
+                log.exception('Error in XBlock LTI parameter processor "%s"', processor)
+
         headers = {
             # This is needed for body encoding:
             'Content-Type': 'application/x-www-form-urlencoded',

--- a/lti_consumer/tests/unit/test_utils.py
+++ b/lti_consumer/tests/unit/test_utils.py
@@ -3,7 +3,7 @@ Utility functions used within unit tests
 """
 
 from webob import Request
-from mock import Mock
+from mock import patch, Mock, PropertyMock
 
 from xblock.fields import ScopeIds
 from xblock.runtime import KvsFieldData, DictKeyValueStore
@@ -54,3 +54,68 @@ def make_request(body, method='POST'):
     request.body = body.encode('utf-8')
     request.method = method
     return request
+
+
+def patch_signed_parameters(func):
+    """
+    Prepare the patches for the get_signed_lti_parameters function for tests.
+    """
+    func = patch(
+        'lti_consumer.lti.get_oauth_request_signature',
+        Mock(return_value=(
+            'OAuth oauth_nonce="fake_nonce", '
+            'oauth_timestamp="fake_timestamp", oauth_version="fake_version", oauth_signature_method="fake_method", '
+            'oauth_consumer_key="fake_consumer_key", oauth_signature="fake_signature"'
+        ))
+    )(func)
+
+    func = patch(
+        'lti_consumer.lti_consumer.LtiConsumerXBlock.prefixed_custom_parameters',
+        PropertyMock(return_value={u'custom_param_1': 'custom1', u'custom_param_2': 'custom2'})
+    )(func)
+
+    func = patch(
+        'lti_consumer.lti_consumer.LtiConsumerXBlock.lti_provider_key_secret',
+        PropertyMock(return_value=('t', 's'))
+    )(func)
+
+    func = patch(
+        'lti_consumer.lti_consumer.LtiConsumerXBlock.user_id', PropertyMock(return_value=FAKE_USER_ID)
+    )(func)
+
+    return func
+
+
+def dummy_processor(_xblock):
+    """
+    A dummy LTI parameter processor.
+    """
+    return {
+        'custom_author_email': 'author@example.com',
+        'custom_author_country': '',
+    }
+
+
+def defaulting_processor(_xblock):
+    """
+    A dummy LTI parameter processor with default params.
+    """
+    pass
+
+
+defaulting_processor.lti_xblock_default_params = {
+    'custom_name': 'Lex',
+    'custom_country': '',
+}
+
+
+def faulty_processor(_xblock):
+    """
+    A dummy LTI parameter processor with default params that throws an error.
+    """
+    raise Exception()
+
+
+faulty_processor.lti_xblock_default_params = {
+    'custom_name': 'Lex',
+}

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='lti_consumer-xblock',
-    version='1.1.8',
+    version='1.2.0',
     description='This XBlock implements the consumer side of the LTI specification.',
     packages=[
         'lti_consumer',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,6 +2,7 @@
 
 django-nose==1.4.4
 astroid==1.3.8  # Pinning to avoid backwards incompatibility issue with pylint/pylint-django
+ddt
 coveralls
 mock
 pep8


### PR DESCRIPTION
### Overview
This pull request makes this XBlock extensible for adding parameters to the LTI provider in addition to the existing ones.

#### Why
A customer needs `team` and `cohort` informaiton to be passed through the LTI channel to simplify integration with their LTI provider. At the same time we'd rather not fork the XBlock, so an Open-Closed model is needed.

### More Detailed Documentation
I've added a couple of sections to `README.rst` to document specifying design and configuration steps of the new LTI parameter processors. Please check it out for more information about the changes that this pull request introduces.
#### Example Usage
I've written a package that we'll need to use for our customer to pass some personal user information in addition to the cohort and team info: https://github.com/appsembler/tahoe-lti/pull/1

### TODO
 - [x] Design review by the Open edX Architects [see more on Slack.](https://openedx.slack.com/archives/C0RU5BTCP/p1541533584041800)
 - [x] Privacy and GDPR review by edX: The edX legal team have confirmed that passing the parameters optionally is OK from the edX privacy standards.
 - [x] Update the README
 - [x] Add tests
 - [x] Add a workbench scenario
 - [x] Test on devstack Studio and LMS
    * `XBLOCK_SETTINGS` are not supported in Studio. My best guess is that `SettingsService` isn't enabled in Studio.
 - [ ] **Optional**: Get the workbench updates merged: https://github.com/edx/xblock-sdk/pull/142

### Timeline
 - [x] Get the critical design and architecture review by Nov 14th, 2018.
   * The discussion has been concluded in [Open edX #architecture Slack](https://openedx.slack.com/archives/C0RU5BTCP/p1541533584041800).
 - [ ] We (Appsembler) would love to get this PR merged by Q1 2019 so we can deploy at our production environment before the  next Open edX release upgrade. The earlier the better.
