### PR TITLE
Updated fragment import to remove depreciation warning

### DIFF
--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -65,8 +65,8 @@ from django.utils import timezone
 from webob import Response
 from xblock.core import List, Scope, String, XBlock
 from xblock.fields import Boolean, Float, Integer
-from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
+from web_fragments.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def package_data(pkg, roots):
 
 setup(
     name='lti_consumer-xblock',
-    version='1.2.4',
+    version='1.2.5',
     description='This XBlock implements the consumer side of the LTI specification.',
     packages=[
         'lti_consumer',


### PR DESCRIPTION
## [PROD-1388](https://openedx.atlassian.net/browse/PROD-1388)

Updated fragment import to remove deprecation warning to avoid unnecessary logs in Splunk