### PR TITLE
Show graded unit icon

### DIFF
--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -250,6 +250,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     """
 
     block_settings_key = 'lti_consumer'
+    icon_class = 'problem'
 
     display_name = String(
         display_name=_("Display Name"),

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def package_data(pkg, roots):
 
 setup(
     name='lti_consumer-xblock',
-    version='1.2.5',
+    version='1.2.6',
     description='This XBlock implements the consumer side of the LTI specification.',
     packages=[
         'lti_consumer',


### PR DESCRIPTION
This shows the 'problem' icon for LTI units, rather than the default 'other' icon.

https://openedx.atlassian.net/browse/AA-75