### PR TITLE
[BD-2] BB-2233: Conditionally hide Studio fields depending on LTI version

### DIFF
--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -309,7 +309,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     # Client ID and block key
     lti_1p3_client_id = String(
         display_name=_("LTI 1.3 Block Client ID"),
-        default=str(uuid.uuid4()),
+        default='',
         scope=Scope.settings
     )
     # This key isn't editable, and should be regenerated
@@ -317,7 +317,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     # This isn't what happens right now though
     lti_1p3_block_key = String(
         display_name=_("LTI 1.3 Block Key"),
-        default=RSA.generate(2048).export_key('PEM'),
+        default='',
         scope=Scope.settings
     )
 
@@ -492,9 +492,6 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         'display_name', 'description',
         # LTI 1.3 variables
         'lti_version', 'lti_1p3_launch_url', 'lti_1p3_oidc_url', 'lti_1p3_tool_public_key',
-        # TODO: implement a proper default setter method on XBlock Fields API.
-        # This is just a workaround the issue.
-        'lti_1p3_client_id', 'lti_1p3_block_key',
         # LTI 1.1 variables
         'lti_id', 'launch_url',
         # Other parameters
@@ -813,6 +810,28 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         fragment.initialize_js('LtiConsumerXBlockInitStudio')
 
         return fragment
+
+    def clean_studio_edits(self, data):
+        """
+        This is a handler to set hidden Studio variables for LTI 1.3.
+
+        These variables shouldn't be editable by the user, but need
+        to be automatically generated for each instance:
+        * lti_1p3_client_id: random uuid (requirement: must be unique)
+        * lti_1p3_block_key: PEM export of 2048-bit RSA key.
+
+        TODO: Remove this once the XBlock Fields API support using
+        a default computed value.
+        """
+        if data.get('lti_version') == 'lti_1p3':
+            # Check if values already exist before populating
+            # to avoid overwriting these keys on every edit.
+            if not self.lti_1p3_client_id:
+                data['lti_1p3_client_id'] = str(uuid.uuid4())
+            if not self.lti_1p3_block_key:
+                data['lti_1p3_block_key'] = RSA.generate(2048).export_key('PEM')
+
+        return super(LtiConsumerXBlock, self).clean_studio_edits(data)
 
     def author_view(self, context):
         """

--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -802,6 +802,18 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             rsa_key_id=self.lti_1p3_client_id
         )
 
+    def studio_view(self, context):
+        """
+        Get Studio View fragment
+        """
+        loader = ResourceLoader(__name__)
+        fragment = super(LtiConsumerXBlock, self).studio_view(context)
+
+        fragment.add_javascript(loader.load_unicode("static/js/xblock_studio_view.js"))
+        fragment.initialize_js('LtiConsumerXBlockInitStudio')
+
+        return fragment
+
     def author_view(self, context):
         """
         XBlock author view of this component.

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -1,0 +1,70 @@
+/**
+ * Javascript for LTI Consumer Studio View.
+*/
+function LtiConsumerXBlockInitStudio(runtime, element) {
+    // Run parent function to set up studio view base JS
+    StudioEditableXBlockMixin(runtime, element);
+
+    // Define LTI 1.1 and 1.3 fields
+    const Lti1P1FieldList = [
+        "lti_id",
+        "launch_url"
+    ];
+
+    const Lti1P3FieldList = [
+        "lti_1p3_launch_url",
+        "lti_1p3_oidc_url",
+        "lti_1p3_tool_public_key"
+    ];
+
+    /**
+     * Query a field using the `data-field-name` attribute and hide/show it.
+     *
+     * params:
+     *   field: string. Value of the field's `data-field-name` attribute.
+     *   visible: boolean. `true` shows the container, and `false` hides it.
+     */
+    function toggleFieldVisibility(field, visible) {
+        const componentQuery = '[data-field-name="'+ field + '"]';
+        const fieldContainer = element.find(componentQuery);
+
+        console.log(field);
+        if (visible) {
+            fieldContainer.show();
+        } else {
+            fieldContainer.hide();
+        }
+    }
+
+    /**
+     * Show or hide LTI fields depending on which version is selected in
+     * the lti_version field.
+     */
+    function toggleLtiFields() {
+        const ltiVersionField = $(element).find('#xb-field-edit-lti_version');
+        const selectedVersion = ltiVersionField.children("option:selected").val();
+
+        Lti1P1FieldList.forEach(function (field) {
+            toggleFieldVisibility(
+                field,
+                selectedVersion === "lti_1p1"
+            );
+        });
+
+        Lti1P3FieldList.forEach(function (field) {
+            toggleFieldVisibility(
+                field,
+                selectedVersion === "lti_1p3"
+            );
+        });
+    }
+
+    // Call once component is instanced to hide fields
+    toggleLtiFields();
+
+    // Bind to onChange method of lti_version selector
+    $(element).find('#xb-field-edit-lti_version').bind('change', function() {
+        toggleLtiFields();
+     });
+
+}

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -6,12 +6,12 @@ function LtiConsumerXBlockInitStudio(runtime, element) {
     StudioEditableXBlockMixin(runtime, element);
 
     // Define LTI 1.1 and 1.3 fields
-    const Lti1P1FieldList = [
+    const lti1P1FieldList = [
         "lti_id",
         "launch_url"
     ];
 
-    const Lti1P3FieldList = [
+    const lti1P3FieldList = [
         "lti_1p3_launch_url",
         "lti_1p3_oidc_url",
         "lti_1p3_tool_public_key"
@@ -28,7 +28,6 @@ function LtiConsumerXBlockInitStudio(runtime, element) {
         const componentQuery = '[data-field-name="'+ field + '"]';
         const fieldContainer = element.find(componentQuery);
 
-        console.log(field);
         if (visible) {
             fieldContainer.show();
         } else {
@@ -44,14 +43,14 @@ function LtiConsumerXBlockInitStudio(runtime, element) {
         const ltiVersionField = $(element).find('#xb-field-edit-lti_version');
         const selectedVersion = ltiVersionField.children("option:selected").val();
 
-        Lti1P1FieldList.forEach(function (field) {
+        lti1P1FieldList.forEach(function (field) {
             toggleFieldVisibility(
                 field,
                 selectedVersion === "lti_1p1"
             );
         });
 
-        Lti1P3FieldList.forEach(function (field) {
+        lti1P3FieldList.forEach(function (field) {
             toggleFieldVisibility(
                 field,
                 selectedVersion === "lti_1p3"


### PR DESCRIPTION
This PR adds some javascript to conditionally hide LTI 1.1/1.3 fields depending on the selected version. This also improves the default value setting for LTI 1.3 secrets and removes the need of passing those to the frontend to be properly saved. 

**Jira tickets:** 
- https://openedx.atlassian.net/browse/TNL-7195
- https://openedx.atlassian.net/browse/OSPR-4463

**Testing instructions:**
f3fe0705520860e8e6868357a129c4a19cfe8e10: 
1. Add a `lti_consumer` block to a course.
2. Edit the block, check that LTI 1.3 fields are hidden.
3. Select LTI 1.3 on the version field, check that LTI 1.1 fields get hidden and LTI 1.3 are shown.

fed41f125532225aa157d74442cc01dfe1fa3fb7:
1. Add a `lti_consumer` block to a course.
2. Publish.
3. Go to LMS and check that the LTI 1.3 variables (`lti_1p3_client_id` and `lti_1p3_block_key`) are not set in the Instructor Debug view.
4. Edit the block on studio, select LTI 1.3, save.
5. Publish.
6. Check that the values were generated on the instructor debug view.
7. Check that the value for client id displayed on Studio is the same as the one in the instructor debug view.
8. Additionally, try editing and saving a few settings on Studio, and check that the ID and RSA didn't change after they were first set.

**Reviewer:**
- [ ] @viadanna
- [ ] @davidjoy or @davestgermain 