### PR TITLE
[BD-2] Switch to external user id.

### DIFF
--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -671,6 +671,16 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         return six.text_type(six.moves.urllib.parse.quote(user_id))
 
     @property
+    def external_user_id(self):
+        """
+        Returns the opaque external user id for the current user.
+        """
+        user_id = self.runtime.service(self, 'user').get_external_user_id('lti')
+        if user_id is None:
+            raise LtiError(self.ugettext("Could not get user id for current request"))
+        return six.text_type(six.moves.urllib.parse.quote(user_id))
+
+    @property
     def resource_link_id(self):
         """
         This is an opaque unique identifier that the LTI Tool Consumer guarantees will be unique
@@ -971,7 +981,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         # Pass user data
         lti_consumer.set_user_data(
-            user_id=self.runtime.user_id,
+            user_id=self.external_user_id,
             # Pass django user role to library
             role=self.runtime.get_user_role()
         )
@@ -991,10 +1001,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             )
         })
 
-        context.update({
-            'launch_url': self.lti_1p3_launch_url,
-            'user': self.runtime.user_id
-        })
+        context.update({'launch_url': self.lti_1p3_launch_url})
         template = loader.render_mako_template('/templates/html/lti_1p3_launch.html', context)
         return Response(template, content_type='text/html')
 


### PR DESCRIPTION
This PR switches the usage of `runtime.user_id` by the external user id present in the latest XBlock runtime version.

**Testing instructions:** 
1. Using a test provider setup, install this branch.
2. Launch the IMS Global Reference tool.
3. Check that the user id received is not the Django ID, but the external user ID provided by the block runtime (using the `external_user_ids` app).

Detailed setup instructions here: https://github.com/edx/xblock-lti-consumer/pull/58

**Reviewer:**
- [ ] @davidjoy 
- [ ] @davestgermain 