### PR TITLE
Fixing extra colons in LTI key

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -656,7 +656,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         for lti_passport in self.course.lti_passports:
             try:
-                # NOTE(sksankarraj)  Now it accepts lti_passports with more than one colons for lit key.
+                # NOTE While upacking the lti_passport by using ":" as delimiter, first item will be lti_id, last item will be client_secret and the rest are considered as client_key. So you can have more than one colon for client_key.
                 lti_id, *key, secret = [i.strip() for i in lti_passport.split(':')]
                 if not key:
                     raise ValueError

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -656,12 +656,11 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         for lti_passport in self.course.lti_passports:
             try:
-                lti_values = [i.strip() for i in lti_passport.split(':')]
-                if len(lti_values) < 3:
+                # NOTE(sksankarraj)  
+                lti_id, *key, secret = [i.strip() for i in lti_passport.split(':')]
+                if not key:
                     raise ValueError
-                lti_id = lti_values[0]
-                key = ':'.join(lti_values[1:-1])
-                secret = lti_values[-1]
+                key = ':'.join(key)
             except ValueError:
                 msg = 'Could not parse LTI passport: {lti_passport!r}. Should be "id:key:secret" string.'
                 msg = self.ugettext(msg).format(lti_passport=lti_passport)

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -656,7 +656,9 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         for lti_passport in self.course.lti_passports:
             try:
-                # NOTE While upacking the lti_passport by using ":" as delimiter, first item will be lti_id, last item will be client_secret and the rest are considered as client_key. So you can have more than one colon for client_key.
+                # NOTE While unpacking the lti_passport by using ":" as delimiter, first item will be lti_id,
+                #  last item will be client_secret and the rest are considered as client_key.
+                #  So you can have more than one colon for client_key.
                 lti_id, *key, secret = [i.strip() for i in lti_passport.split(':')]
                 if not key:
                     raise ValueError

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -656,7 +656,10 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         for lti_passport in self.course.lti_passports:
             try:
-                lti_id, key, secret = [i.strip() for i in lti_passport.split(':')]
+                lti_values = [i.strip() for i in lti_passport.split(':')]
+                lti_id = lti_values[0]
+                key = ':'.join(lti_values[1:-1])
+                secret = lti_values[-1]
             except ValueError:
                 msg = 'Could not parse LTI passport: {lti_passport!r}. Should be "id:key:secret" string.'
                 msg = self.ugettext(msg).format(lti_passport=lti_passport)

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -656,7 +656,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         for lti_passport in self.course.lti_passports:
             try:
-                # NOTE(sksankarraj)  
+                # NOTE(sksankarraj)  Now it accepts lti_passports with more than one colons for lit key.
                 lti_id, *key, secret = [i.strip() for i in lti_passport.split(':')]
                 if not key:
                     raise ValueError

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -657,6 +657,8 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         for lti_passport in self.course.lti_passports:
             try:
                 lti_values = [i.strip() for i in lti_passport.split(':')]
+                if len(lti_values) < 3:
+                    raise ValueError
                 lti_id = lti_values[0]
                 key = ':'.join(lti_values[1:-1])
                 secret = lti_values[-1]

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -171,6 +171,22 @@ class TestProperties(TestLtiConsumerXBlock):
         self.assertEqual(lti_provider_secret, secret)
 
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
+    def test_lti_provider_key_with_extra_colons(self, mock_course):
+        """
+        Test `lti_provider_key` returns correct key and secret, even if key has more colons.
+        """
+        provider = 'lti_provider'
+        key = '1:10:test'
+        secret = 'secret'
+        self.xblock.lti_id = provider
+        type(mock_course).lti_passports = PropertyMock(return_value=["{}:{}:{}".format(provider, key, secret)])
+        lti_provider_key, lti_provider_secret = self.xblock.lti_provider_key_secret
+
+        self.assertEqual(lti_provider_key, key)
+        self.assertEqual(lti_provider_secret, secret)
+        
+
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
     def test_lti_provider_key_secret_not_found(self, mock_course):
         """
         Test `lti_provider_key_secret` returns correct key and secret

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -184,7 +184,6 @@ class TestProperties(TestLtiConsumerXBlock):
 
         self.assertEqual(lti_provider_key, key)
         self.assertEqual(lti_provider_secret, secret)
-        
 
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
     def test_lti_provider_key_secret_not_found(self, mock_course):


### PR DESCRIPTION
Problem Statement:

We had a situation where we faced an issue with parsing the LTI passports because of extra colons in them.

LTI passports are parsed by using colon(:) as a delimiter. We were trying to integrate LTI content from Rustici controller, the key format of the provider is `content:<unit-no>:<id>` the LTI passport will like 

`<content_id>:content:<unit-no>:<provider_id>:<secret_key>`

So this results to throwing unformatted Key exception.

Hope this PR will fix that issue.