### PR TITLE
[BD-24] [TNL-7316] Implement context claim on LTI 1.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ root folder:
 
     $ pip install -r requirements/base.txt
 
-Addtitionally, to enable LTI 1.3 Launch support, the following FEATURE flag needs to be set in `studio.yml`:
+Addtitionally, to enable LTI 1.3 Launch support, the following FEATURE flag needs to be set in `/edx/etc/studio.yml` in your LMS container:
 
 .. code:: yaml
 
@@ -98,36 +98,50 @@ On LTI 1.3 the authentication mechanism used is OAuth2 using the Client Credenti
 that to configure the tool, the LMS needs to know the Keyset URL or public key of the tool, and the tool
 needs to know the LMS's one.
 
-Intructions:
+Instructions:
 
 1. Set up a local tunnel tunneling the LMS (using `ngrok` or a similar tool) to get a URL accessible from the internet.
-3. Create a new course, and add the `lti_consumer` block to the advanced modules list.
-4. In the course, create a new unit and add the LTI block.
-5. In studio, you'll see a few parameters being displayed in the preview:
-```
-Client: f0532860-cb34-47a9-b16c-53deb077d4de
-Deployment ID: 1
-# Note that these are LMS URLS
-Keyset URL: http://localhost:18000/api/lti_consumer/v1/public_keysets/block-v1:OpenCraft+LTI101+2020_T2+type@lti_consumer+block@efc55c7abb87430883433bfafb83f054
-OAuth Token URL: http://localhost:18000/api/lti_consumer/v1/token/block-v1:OpenCraft+LTI101+2020_T2+type@lti_consumer+block@efc55c7abb87430883433bfafb83f054
-OIDC Callback URL: http://localhost:18000/api/lti_consumer/v1/launch/
-```
-6. Add the tunnel url to the keyset url as it'll need to be accessed by the tool (hosted externally).
-```
-# This is <LMS_URL>/api/lti_consumer/v1/launch/<BLOCK_LOCATION>
-https://647dd2e1.ngrok.io/api/lti_consumer/v1/public_keysets/block-v1:OpenCraft+LTI101+2020_T2+type@lti_consumer+block@996c72b16070434098bc598bd7d6dbde
-```
-7. Set up a tool in the IMS Global reference implementation (https://lti-ri.imsglobal.org/lti/tools/).
- * Click on __Add tool__ at the top of the page (https://lti-ri.imsglobal.org/lti/tools).
- * Add the parameters and URLs provided by the block, and generate a private key on https://lti-ri.imsglobal.org/keygen/index and paste it there (don't close the tab, you'll need the public key later).
-8. Go back to Studio, and edit the block adding it's settings (you'll find them by scrolling down https://lti-ri.imsglobal.org/lti/tools/ until you find the tool you just created):
-```
-Tool launch URL: https://lti-ri.imsglobal.org/lti/tools/[tool_id]/launches
-Tool OIDC Login Initiation URL: https://lti-ri.imsglobal.org/lti/tools/[tool_id]/login_initiations
-Tool public key: Public key from key page.
-```
+2. Create a new course, and add the `lti_consumer` block to the advanced modules list.
+3. In the course, create a new unit and add the LTI block.
+
+   * Set ``LTI Version`` to ``LTI 1.3``.
+   * Set the ``LTI 1.3 Tool Launch URL`` to ``https://lti-ri.imsglobal.org/lti/tools/``
+
+4. In studio, you'll see a few parameters being displayed in the preview:
+
+.. code::
+
+    Client: f0532860-cb34-47a9-b16c-53deb077d4de
+    Deployment ID: 1
+    # Note that these are LMS URLS
+    Keyset URL: http://localhost:18000/api/lti_consumer/v1/public_keysets/block-v1:OpenCraft+LTI101+2020_T2+type@lti_consumer+block@efc55c7abb87430883433bfafb83f054
+    OAuth Token URL: http://localhost:18000/api/lti_consumer/v1/token/block-v1:OpenCraft+LTI101+2020_T2+type@lti_consumer+block@efc55c7abb87430883433bfafb83f054
+    OIDC Callback URL: http://localhost:18000/api/lti_consumer/v1/launch/
+
+
+5. Add the tunnel URL to the each of these URLs as it'll need to be accessed by the tool (hosted externally).
+
+.. code::
+
+    # This is <LMS_URL>/api/lti_consumer/v1/public_keysets/<BLOCK_LOCATION>
+    https://647dd2e1.ngrok.io/api/lti_consumer/v1/public_keysets/block-v1:OpenCraft+LTI101+2020_T2+type@lti_consumer+block@996c72b16070434098bc598bd7d6dbde
+
+
+6. Set up a tool in the IMS Global reference implementation (https://lti-ri.imsglobal.org/lti/tools/).
+
+   * Click on ``Add tool`` at the top of the page (https://lti-ri.imsglobal.org/lti/tools).
+   * Add the parameters and URLs provided by the block, and generate a private key on https://lti-ri.imsglobal.org/keygen/index and paste it there (don't close the tab, you'll need the public key later).
+
+7. Go back to Studio, and edit the block adding its settings (you'll find them by scrolling down https://lti-ri.imsglobal.org/lti/tools/ until you find the tool you just created):
+
+.. code::
+
+    LTI 1.3 Tool Launch URL: https://lti-ri.imsglobal.org/lti/tools/[tool_id]/launches
+    LTI 1.3 OIDC URL: https://lti-ri.imsglobal.org/lti/tools/[tool_id]/login_initiations
+    LTI 1.3 Tool Public key: Public key from key page.
+
 8. Publish block, log into LMS and navigate to the LTI block page.
-9. Check that the LTI launch was successful.
+9. Click ``Send Request`` and verify that the LTI launch was successful.
 
 Custom LTI Parameters
 ---------------------

--- a/lti_consumer/lti_1p3/constants.py
+++ b/lti_consumer/lti_1p3/constants.py
@@ -5,6 +5,8 @@ This includes the LTI Base message, OAuth2 scopes, and
 lists of required and optional parameters required for
 LTI message generation and validation.
 """
+from enum import Enum
+
 
 LTI_BASE_MESSAGE = {
     # Claim type: fixed key with value `LtiResourceLinkRequest`
@@ -43,3 +45,11 @@ LTI_1P3_ACCESS_TOKEN_REQUIRED_CLAIMS = set([
 ])
 
 LTI_1P3_ACCESS_TOKEN_SCOPES = []
+
+
+class LTI_1P3_CONTEXT_TYPE(Enum):  # pylint: disable=invalid-name
+    """ LTI 1.3 Context Claim Types """
+    group = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseGroup'
+    course_offering = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseOffering'
+    course_section = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection'
+    course_template = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseTemplate'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -81,6 +81,7 @@ from .lti_1p3.exceptions import (
     TokenSignatureExpired,
     UnknownClientId,
 )
+from .lti_1p3.constants import LTI_1P3_CONTEXT_TYPE
 from .lti_1p3.consumer import LtiConsumer1p3
 from .outcomes import OutcomeService
 from .utils import (
@@ -1084,6 +1085,19 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             # either `iframe`, `frame` or `window`
             # This is optional though
             lti_consumer.set_launch_presentation_claim('iframe')
+
+            # Set context claim
+            # This is optional
+            context_title = " - ".join([
+                self.course.display_name_with_default,
+                self.course.display_org_with_default
+            ])
+            lti_consumer.set_context_claim(
+                self.context_id,
+                context_types=[LTI_1P3_CONTEXT_TYPE.course_offering],
+                context_title=context_title,
+                context_label=self.context_id
+            )
 
             context.update({
                 "preflight_response": dict(request.GET),

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1169,12 +1169,15 @@ class TestLtiConsumer1p3XBlock(TestCase):
     @patch('lti_consumer.lti_xblock.get_lms_base', return_value="https://example.com")
     def test_launch_callback_endpoint(self, mock_url, mock_url_2):
         """
-        Test that the LTI 1.3 callback endpoind.
+        Test the LTI 1.3 callback endpoint.
         """
         self.xblock.runtime.get_user_role.return_value = 'student'
         mock_user_service = Mock()
         mock_user_service.get_external_user_id.return_value = 2
         self.xblock.runtime.service.return_value = mock_user_service
+
+        self.xblock.course.display_name_with_default = 'course_display_name'
+        self.xblock.course.display_org_with_default = 'course_display_org'
 
         # Craft request sent back by LTI tool
         request = make_request('', 'GET')
@@ -1206,6 +1209,9 @@ class TestLtiConsumer1p3XBlock(TestCase):
         mock_user_service = Mock()
         mock_user_service.get_external_user_id.return_value = 2
         self.xblock.runtime.service.return_value = mock_user_service
+
+        self.xblock.course.display_name_with_default = 'course_display_name'
+        self.xblock.course.display_org_with_default = 'course_display_org'
 
         # Make a fake invalid preflight request, with empty parameters
         request = make_request('', 'GET')

--- a/lti_consumer/tests/unit/test_outcomes.py
+++ b/lti_consumer/tests/unit/test_outcomes.py
@@ -11,7 +11,7 @@ from mock import Mock, PropertyMock, patch
 
 from lti_consumer.exceptions import LtiError
 from lti_consumer.outcomes import OutcomeService, parse_grade_xml_body
-from lti_consumer.tests.unit.test_lti_consumer import TestLtiConsumerXBlock
+from lti_consumer.tests.unit.test_lti_xblock import TestLtiConsumerXBlock
 from lti_consumer.tests.unit.test_utils import make_request
 
 REQUEST_BODY_TEMPLATE_VALID = textwrap.dedent("""

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='2.0.2',
+    version='2.0.3',
     description='This XBlock implements the consumer side of the LTI specification.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Implement context claim on LTI1.3

**JIRA tickets**:
[OSPR-4795](https://openedx.atlassian.net/browse/OSPR-4795)
[TNL-7316](https://openedx.atlassian.net/browse/TNL-7316)

**Merge deadline**: None

**Testing instructions**:

1. Pull the `open-craft:patrick/BB-2516-lti-improvements-implement-context-claim-on-lti` branch locally.
2. Launch your LMS from the devstack with `make lms-shell`
3. Edit `/edx/etc/studio.yml` and ensure the `LTI_1P3_ENABLED` flag exists and is set to `true`:
```
FEATURE:
    LTI_1P3_ENABLED: true
```
4. Follow instructions on the [README](https://github.com/open-craft/xblock-lti-consumer/tree/patrick/BB-2516-lti-improvements-implement-context-claim-on-lti#installing-in-docker-devstack) for installing the `xblock-lti-consumer` package
5. Install [`ngrok`](https://ngrok.com/) or a similar tool locally.
6. Launch `ngrok` with `ngrok http 18000`. Do not close your `ngrok` tunnel during the test. From here on, this URL will be referred to as `<NGROK_URL>`. It will be of the following form:
```
http://<RANDOM_ID>.ngrok.io
``` 
7. Create a course in Studio and navigate to `Settings > Advanced Settings`. Add `"lti_consumer"` to the advanced modules list.
8. Modify the course content and add a new unit. Add the LTI block to the new unit
  * Set the `LTI Version` to `LTI 1.3`
  * Set the `LTI 1.3 Tool Launch URL` to `https://lti-ri.imsglobal.org/lti/tools/`
9. Once the block is added, a preview with multiple parameters will be displayed. Copy these parameters to an external location you can edit. It will look like this:
```
    Client: f0532860-cb34-47a9-b16c-53deb077d4de
    Deployment ID: 1
    # Note that these are LMS URLS
    Keyset URL: http://localhost:18000/api/lti_consumer/v1/public_keysets/<BLOCK_ID>
    OAuth Token URL: http://localhost:18000/api/lti_consumer/v1/token/<BLOCK_ID>
    OIDC Callback URL: http://localhost:18000/api/lti_consumer/v1/launch/
```
10. Replace `http://localhost:18000` in each of those URLs with your NGROK URL.
```
    Client: f0532860-cb34-47a9-b16c-53deb077d4de
    Deployment ID: 1
    # Note that these are LMS URLS
    Keyset URL: <NGROK_URL>/api/lti_consumer/v1/public_keysets/<BLOCK_ID>
    OAuth Token URL: <NGROK_URL>/api/lti_consumer/v1/token/<BLOCK_ID>
    OIDC Callback URL: <NGROK_URL>/api/lti_consumer/v1/launch/
```
11. Navigate to the [IMS Global reference implementation](https://lti-ri.imsglobal.org/lti/tools/) tools page and setup a tool.
  * In a separate tab, navigate to https://lti-ri.imsglobal.org/keygen/index to generate a public/private key pair. Do not close this tab!
  * Click `Add tool` at the top of the page
  * Enter the parameters and URLs you modified above (that include your NGROK URL), as well as the private key into the tool information
  * Once your tool is created, make note of the `tool_id` which will be an integer towards the end of the URL for your completed tool
12. Go back to the Studio, and edit the LTI block. Set the following settings:
```
    LTI 1.3 Tool Launch URL: https://lti-ri.imsglobal.org/lti/tools/<TOOL_ID>/launches
    LTI 1.3 OIDC URL: https://lti-ri.imsglobal.org/lti/tools/<TOOL_ID>/login_initiations
    LTI 1.3 Tool Public key: Public key from key page.
``` 
13. Publish your block.
14. Navigate to the LMS by way of your NGROK URL and log in. Please note that you MUST use the NGROK URL, and that the traditional LMS URL of `http://localhost:18000` will NOT work.
15. Navigate to the unit containing the LTI block, and click `Send Request`
16. Make note of the launch status and of the claims the launch received. In particular, look for the context claim contents.

**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD