### PR TITLE
[BD-29] [TNL-6993] [BB-2706] Make LTI Consumer indexable

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1471,3 +1471,26 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'lti_2_0_result_rest_handler': 'result_service_url'
         }
         return getattr(self, mapping[service_name])
+
+    def index_dictionary(self):
+        """
+        Return dictionary prepared with module content and type for indexing.
+        """
+        # return key/value fields in a Python dict object
+        # values may be numeric / string or dict
+        # default implementation is an empty dict
+        xblock_body = super(LtiConsumerXBlock, self).index_dictionary()
+
+        index_body = {
+            "display_name": self.display_name,
+            "description": self.description,
+        }
+
+        if "content" in xblock_body:
+            xblock_body["content"].update(index_body)
+        else:
+            xblock_body["content"] = index_body
+
+        xblock_body["content_type"] = "LTI Consumer"
+
+        return xblock_body

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -42,6 +42,32 @@ class TestLtiConsumerXBlock(TestCase):
         self.xblock = make_xblock('lti_consumer', LtiConsumerXBlock, self.xblock_attributes)
 
 
+class TestIndexibility(TestCase):
+    """
+    Test indexibility of Lti Consumer XBlock
+    """
+    def setUp(self):
+        super(TestIndexibility, self).setUp()
+        self.xblock_attributes = {
+            'launch_url': 'http://www.example.com',
+            'display_name': 'Example LTI Consumer Application',
+            'description': 'An example application to demonstrate LTI Consumer'
+        }
+        self.xblock = make_xblock('lti_consumer', LtiConsumerXBlock, self.xblock_attributes)
+
+    def test_indexibility(self):
+        self.assertEqual(
+            self.xblock.index_dictionary(),
+            {
+                'content_type': 'LTI Consumer',
+                'content': {
+                    'display_name': 'Example LTI Consumer Application',
+                    'description': 'An example application to demonstrate LTI Consumer'
+                }
+            }
+        )
+
+
 class TestProperties(TestLtiConsumerXBlock):
     """
     Unit tests for LtiConsumerXBlock properties

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='2.0.3',
+    version='2.1.0',
     description='This XBlock implements the consumer side of the LTI specification.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Make LTI Consumer Indexable

**JIRA tickets**: 
* https://openedx.atlassian.net/browse/TNL-6993

**Merge deadline**: "None"

**Testing instructions**:

1. Clone this repo in `src` directory of your devstacks.
2. Checkout this branch i.e `ahmed/bb-2706-make-lti-consumer-indexable`
3. Install the cloned project into both **LMS** and **Studio** by changing your directory to the `src/xblock-lti-consumer` directory in your devstack and executing `pip install -e .`
4. Add `lti_consumer` to the Advanced Module List. See https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html#enabling-lti-components-for-a-course
5. Create a sample LTI Consumer Block.
6. Reindex your course.
7. Go to LMS and search for some string that appears in either the name or description of LTI Consumer XBlock.

**Reviewers**
- [ ] @xitij2000 
- [ ] @davestgermain