### PR TITLE
[BD-24] [TNL-7318]: BB-2355 - Add decoding and scope verification methods

### DIFF
--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -397,3 +397,26 @@ class LtiConsumer1p3:
             assert response.get("redirect_uri") == self.launch_url
         except AssertionError:
             raise exceptions.PreflightRequestValidationFailure()
+
+    def check_token(self, token, allowed_scopes=None):
+        """
+        Check if token has access to allowed scopes.
+        """
+        token_contents = self.key_handler.validate_and_decode(
+            token,
+            # The issuer of the token is the platform
+            iss=self.iss,
+        )
+        # Tokens are space separated
+        token_scopes = token_contents['scopes'].split(' ')
+
+        # Check if token has permission for the requested scope,
+        # and throws exception if not.
+        # If `allowed_scopes` is empty, return true (just check
+        # token validity).
+        if allowed_scopes:
+            return any(
+                [scope in allowed_scopes for scope in token_scopes]
+            )
+
+        return True

--- a/lti_consumer/lti_1p3/exceptions.py
+++ b/lti_consumer/lti_1p3/exceptions.py
@@ -34,6 +34,10 @@ class UnsupportedGrantType(Lti1p3Exception):
     pass
 
 
+class InvalidClaimValue(Lti1p3Exception):
+    pass
+
+
 class InvalidRsaKey(Lti1p3Exception):
     pass
 

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -490,3 +490,33 @@ class TestLti1p3Consumer(TestCase):
 
         # Check if token is valid
         self._decode_token(response.get('access_token'))
+
+    def test_check_token_no_scopes(self):
+        """
+        Test if `check_token` method returns True for a valid token without scopes.
+        """
+        token = self.lti_consumer.key_handler.encode_and_sign({
+            "iss": ISS,
+            "scopes": "",
+        })
+        self.assertTrue(self.lti_consumer.check_token(token, None))
+
+    def test_check_token_with_allowed_scopes(self):
+        """
+        Test if `check_token` method returns True for a valid token with allowed scopes.
+        """
+        token = self.lti_consumer.key_handler.encode_and_sign({
+            "iss": ISS,
+            "scopes": "test"
+        })
+        self.assertTrue(self.lti_consumer.check_token(token, ['test', '123']))
+
+    def test_check_token_without_allowed_scopes(self):
+        """
+        Test if `check_token` method returns True for a valid token with allowed scopes.
+        """
+        token = self.lti_consumer.key_handler.encode_and_sign({
+            "iss": ISS,
+            "scopes": "test"
+        })
+        self.assertFalse(self.lti_consumer.check_token(token, ['123', ]))

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='2.1.1',
+    version='2.1.2',
     description='This XBlock implements the consumer side of the LTI specification.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR adds a few token verification mechanisms to support LTI Advantage services.
This is PR 2 of https://github.com/edx/xblock-lti-consumer/pull/92.

**Testing instructions:**
Currently there are no endpoints using this, so just make sure the code is same and checks are passing.

**Reviewer:** 
- [ ] @viadanna 
- [ ] @davidjoy 
- [ ] @davestgermain 