### PR TITLE
Convert is_past_due to a method

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -819,7 +819,6 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         return custom_parameters
 
-    @property
     def is_past_due(self):
         """
         Is it now past this problem's due date, including grace period?
@@ -1244,7 +1243,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             lti_provider_key, lti_provider_secret = self.lti_provider_key_secret
             log_authorization_header(request, lti_provider_key, lti_provider_secret)
 
-        if not self.accept_grades_past_due and self.is_past_due:
+        if not self.accept_grades_past_due and self.is_past_due():
             return Response(status=404)  # have to do 404 due to spec, but 400 is better, with error msg in body
 
         try:

--- a/lti_consumer/outcomes.py
+++ b/lti_consumer/outcomes.py
@@ -159,7 +159,7 @@ class OutcomeService(object):  # pylint: disable=bad-option-value, useless-objec
         }
         request_body = request.body.decode('utf-8')
 
-        if not self.xblock.accept_grades_past_due and self.xblock.is_past_due:
+        if not self.xblock.accept_grades_past_due and self.xblock.is_past_due():
             failure_values['imsx_description'] = "Grade is past due"
             return response_xml_template.format(**failure_values)
 

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -304,7 +304,7 @@ class TestProperties(TestLtiConsumerXBlock):
         self.xblock.due = None
         self.xblock.graceperiod = timedelta(days=1)
 
-        self.assertFalse(self.xblock.is_past_due)
+        self.assertFalse(self.xblock.is_past_due())
 
     def test_is_past_due_with_graceperiod(self):
         """
@@ -314,10 +314,10 @@ class TestProperties(TestLtiConsumerXBlock):
         self.xblock.graceperiod = timedelta(days=1)
 
         self.xblock.due = now
-        self.assertFalse(self.xblock.is_past_due)
+        self.assertFalse(self.xblock.is_past_due())
 
         self.xblock.due = now - timedelta(days=2)
-        self.assertTrue(self.xblock.is_past_due)
+        self.assertTrue(self.xblock.is_past_due())
 
     def test_is_past_due_no_graceperiod(self):
         """
@@ -327,10 +327,10 @@ class TestProperties(TestLtiConsumerXBlock):
         self.xblock.graceperiod = None
 
         self.xblock.due = now - timedelta(days=1)
-        self.assertTrue(self.xblock.is_past_due)
+        self.assertTrue(self.xblock.is_past_due())
 
         self.xblock.due = now + timedelta(days=1)
-        self.assertFalse(self.xblock.is_past_due)
+        self.assertFalse(self.xblock.is_past_due())
 
     def test_is_past_due_timezone_now_called(self):
         """
@@ -340,7 +340,7 @@ class TestProperties(TestLtiConsumerXBlock):
         self.xblock.graceperiod = None
         self.xblock.due = now
         with patch('lti_consumer.lti_xblock.timezone.now', wraps=timezone.now) as mock_timezone_now:
-            __ = self.xblock.is_past_due
+            __ = self.xblock.is_past_due()
             self.assertTrue(mock_timezone_now.called)
 
 
@@ -675,7 +675,7 @@ class TestResultServiceHandler(TestLtiConsumerXBlock):
         Test 404 response returned when `accept_grades_past_due` is False
         and `is_past_due` is True
         """
-        mock_is_past_due.__get__ = Mock(return_value=True)
+        mock_is_past_due.return_value = True
         self.xblock.accept_grades_past_due = False
         response = self.xblock.result_service_handler(make_request('', 'GET'))
 
@@ -688,7 +688,7 @@ class TestResultServiceHandler(TestLtiConsumerXBlock):
         """
         Test 200 response returned when `accept_grades_past_due` is True and `is_past_due` is True
         """
-        mock_is_past_due.__get__ = Mock(return_value=True)
+        mock_is_past_due.return_value = True
         mock_parse_suffix.return_value = FAKE_USER_ID
         self.mock_lti_consumer.get_result.return_value = {}
         response = self.xblock.result_service_handler(make_request('', 'GET'))

--- a/lti_consumer/tests/unit/test_outcomes.py
+++ b/lti_consumer/tests/unit/test_outcomes.py
@@ -356,7 +356,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
             RESPONSE_BODY_TEMPLATE.format(**values).strip()
         )
 
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.is_past_due', PropertyMock(return_value=True))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.is_past_due', Mock(return_value=True))
     def test_grade_past_due(self):
         """
         Test late grade returns failure response

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='2.1.0',
+    version='2.1.1',
     description='This XBlock implements the consumer side of the LTI specification.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This is just to keep it in line with other xblocks that define an is_past_due attribute. Nicer if they all have the same access pattern.