### PR TITLE
Send modal to parent window.

### DIFF
--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -17,6 +17,24 @@ function LtiConsumerXBlock(runtime, element) {
                     var o = options;
                     $(this).click(function (e) {
                         var $modal = $(modal_id);
+                        // If we are already in an iframe, skip creation of the modal, since
+                        // it won't look good, anyway. Instead, we post a message to the parent
+                        // window, requesting creation of a modal there.
+                        // This is used by the courseware microfrontend.
+                        if (window !== window.parent) {
+                            window.parent.postMessage(
+                                {
+                                    'type': 'plugin.modal',
+                                    'payload': {
+                                        'url': window.location.origin + $modal.data('launch-url'),
+                                        'title': $modal.find('iframe').attr('title'),
+                                        'width': $modal.data('width')
+                                    }
+                                },
+                                document.referrer
+                            );
+                            return;
+                        }
                         // Set iframe src attribute to launch LTI provider
                         $modal.find('iframe').attr('src', $modal.data('launch-url'));
                         $("#" + overlay_id).click(function () {

--- a/lti_consumer/templates/html/student.html
+++ b/lti_consumer/templates/html/student.html
@@ -52,6 +52,7 @@
             aria-hidden="true"
             style="width:${modal_width}%; left:${modal_horizontal_offset}%; top:${modal_vertical_offset}%; bottom:${modal_vertical_offset}%;"
             data-launch-url="${form_url}"
+            data-width="${modal_width}%"
         >
             <div class="inner-wrapper" role="dialog">
                 <button class="close-modal">

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='2.1.2',
+    version='2.2',
     description='This XBlock implements the consumer side of the LTI specification.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Because the courseware microfrontend loads units inside iframes, the LTI modal ends up being squished and generally ugly.

This PR introduces a new message sent to the parent window to request a modal containing the contents of the LTI launch iframe.

[TNL-7410](https://openedx.atlassian.net/browse/TNL-7410)