### PR TITLE
Correct the license copies

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,6 @@
-Copyright (C) 2015  edX
+Open edX LTI Consumer Library
+
+Copyright (C) 2015-2020, edX
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by

--- a/README.rst
+++ b/README.rst
@@ -275,7 +275,7 @@ inside project root directory
 License
 -------
 
-The LTI Consumer XBlock is available under the Apache Version 2.0 License.
+The LTI Consumer XBlock is available under the AGPL v3 License.
 
 
 .. |Build Status| image:: https://travis-ci.org/edx/xblock-lti-consumer.svg

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
+        'License :: OSI Approved :: GNU Affero General Public License v3',
         'Natural Language :: English',
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",


### PR DESCRIPTION
We said Apache, and it is Apache, so why have a copy of AGPL?