### PR TITLE
[BD-24][TNL-7580] BB-3010: Implement app view testing infrastructure

### DIFF
--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -1,0 +1,21 @@
+"""
+Compatibility layer to isolate core-platform method calls from implementation.
+"""
+
+
+def run_xblock_handler(*args, **kwargs):
+    """
+    Import and run `handle_xblock_callback` from LMS
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from lms.djangoapps.courseware.module_render import handle_xblock_callback
+    return handle_xblock_callback(*args, **kwargs)
+
+
+def run_xblock_handler_noauth(*args, **kwargs):
+    """
+    Import and run `handle_xblock_callback_noauth` from LMS
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from lms.djangoapps.courseware.module_render import handle_xblock_callback_noauth
+    return handle_xblock_callback_noauth(*args, **kwargs)

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -7,9 +7,9 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
 from opaque_keys.edx.keys import UsageKey
-from lms.djangoapps.courseware.module_render import (  # pylint: disable=import-error
-    handle_xblock_callback,
-    handle_xblock_callback_noauth,
+from lti_consumer.plugin.compat import (
+    run_xblock_handler,
+    run_xblock_handler_noauth,
 )
 
 
@@ -25,13 +25,13 @@ def public_keyset_endpoint(request, usage_id=None):
     try:
         usage_key = UsageKey.from_string(usage_id)
 
-        return handle_xblock_callback_noauth(
+        return run_xblock_handler_noauth(
             request=request,
             course_id=str(usage_key.course_key),
             usage_id=str(usage_key),
             handler='public_keyset_endpoint'
         )
-    except:  # pylint: disable=bare-except
+    except Exception:  # pylint: disable=broad-except
         return HttpResponse(status=404)
 
 
@@ -49,14 +49,14 @@ def launch_gate_endpoint(request, suffix):
             request.GET.get('login_hint')
         )
 
-        return handle_xblock_callback(
+        return run_xblock_handler(
             request=request,
             course_id=str(usage_key.course_key),
             usage_id=str(usage_key),
             handler='lti_1p3_launch_callback',
             suffix=suffix
         )
-    except:  # pylint: disable=bare-except
+    except Exception:  # pylint: disable=broad-except
         return HttpResponse(status=404)
 
 
@@ -69,11 +69,11 @@ def access_token_endpoint(request, usage_id=None):
     try:
         usage_key = UsageKey.from_string(usage_id)
 
-        return handle_xblock_callback_noauth(
+        return run_xblock_handler_noauth(
             request=request,
             course_id=str(usage_key.course_key),
             usage_id=str(usage_key),
             handler='lti_1p3_access_token'
         )
-    except:  # pylint: disable=bare-except
+    except Exception:  # pylint: disable=broad-except
         return HttpResponse(status=404)

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -1,0 +1,109 @@
+"""
+Tests for LTI 1.3 endpoint views.
+"""
+from mock import patch
+
+from django.http import HttpResponse
+from django.test.testcases import TestCase
+
+
+class TestLti1p3KeysetEndpoint(TestCase):
+    """
+    Test `public_keyset_endpoint` method.
+    """
+    def setUp(self):
+        super(TestLti1p3KeysetEndpoint, self).setUp()
+
+        self.location = 'block-v1:course+test+2020+type@problem+block@test'
+        self.url = '/lti_consumer/v1/public_keysets/{}'.format(self.location)
+
+        # Patch settings calls to LMS method
+        xblock_handler_patcher = patch(
+            'lti_consumer.plugin.views.run_xblock_handler_noauth',
+            return_value=HttpResponse()
+        )
+        self.addCleanup(xblock_handler_patcher.stop)
+        self._mock_xblock_handler = xblock_handler_patcher.start()
+
+    def test_public_keyset_endpoint(self):
+        """
+        Check that the keyset endpoint works properly.
+        """
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_invalid_usage_key(self):
+        """
+        Check invalid methods yield HTTP code 405.
+        """
+        response = self.client.get('/lti_consumer/v1/public_keysets/invalid-key')
+        self.assertEqual(response.status_code, 404)
+
+
+class TestLti1p3LaunchGateEndpoint(TestCase):
+    """
+    Test `launch_gate_endpoint` method.
+    """
+    def setUp(self):
+        super(TestLti1p3LaunchGateEndpoint, self).setUp()
+
+        self.location = 'block-v1:course+test+2020+type@problem+block@test'
+        self.url = '/lti_consumer/v1/launch/'
+        self.request = {'login_hint': self.location}
+
+        # Patch settings calls to LMS method
+        xblock_handler_patcher = patch(
+            'lti_consumer.plugin.views.run_xblock_handler',
+            return_value=HttpResponse()
+        )
+        self.addCleanup(xblock_handler_patcher.stop)
+        self._mock_xblock_handler = xblock_handler_patcher.start()
+
+    def test_launch_gate(self):
+        """
+        Check that the launch endpoint works properly.
+        """
+        response = self.client.get(self.url, self.request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_invalid_usage_key(self):
+        """
+        Check invalid login_hint yields HTTP code 404.
+        """
+        self._mock_xblock_handler.side_effect = Exception()
+        response = self.client.get(self.url, self.request)
+        self.assertEqual(response.status_code, 404)
+
+
+class TestLti1p3AccessTokenEndpoint(TestCase):
+    """
+    Test `access_token_endpoint` method.
+    """
+    def setUp(self):
+        super(TestLti1p3AccessTokenEndpoint, self).setUp()
+
+        self.location = 'block-v1:course+test+2020+type@problem+block@test'
+        self.url = '/lti_consumer/v1/token/{}'.format(self.location)
+
+        # Patch settings calls to LMS method
+        xblock_handler_patcher = patch(
+            'lti_consumer.plugin.views.run_xblock_handler_noauth',
+            return_value=HttpResponse()
+        )
+        self.addCleanup(xblock_handler_patcher.stop)
+        self._mock_xblock_handler = xblock_handler_patcher.start()
+
+    def test_access_token_endpoint(self):
+        """
+        Check that the keyset endpoint works properly.
+        """
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_invalid_usage_key(self):
+        """
+        Check invalid methods yield HTTP code 404.
+        """
+        self._mock_xblock_handler.side_effect = Exception()
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 404)

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -35,6 +35,7 @@ class TestLti1p3KeysetEndpoint(TestCase):
         # Check response
         self.assertEqual(response.status_code, 200)
         # Check function call arguments
+        self._mock_xblock_handler.assert_called_once()
         kwargs = self._mock_xblock_handler.call_args.kwargs
         self.assertEqual(kwargs['usage_id'], self.location)
         self.assertEqual(kwargs['handler'], 'public_keyset_endpoint')
@@ -76,6 +77,7 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
         # Check response
         self.assertEqual(response.status_code, 200)
         # Check function call arguments
+        self._mock_xblock_handler.assert_called_once()
         kwargs = self._mock_xblock_handler.call_args.kwargs
         self.assertEqual(kwargs['usage_id'], self.location)
         self.assertEqual(kwargs['handler'], 'lti_1p3_launch_callback')
@@ -117,6 +119,7 @@ class TestLti1p3AccessTokenEndpoint(TestCase):
         # Check response
         self.assertEqual(response.status_code, 200)
         # Check function call arguments
+        self._mock_xblock_handler.assert_called_once()
         kwargs = self._mock_xblock_handler.call_args.kwargs
         self.assertEqual(kwargs['usage_id'], self.location)
         self.assertEqual(kwargs['handler'], 'lti_1p3_access_token')

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -34,7 +34,7 @@ class TestLti1p3KeysetEndpoint(TestCase):
 
     def test_invalid_usage_key(self):
         """
-        Check invalid methods yield HTTP code 405.
+        Check invalid methods yield HTTP code 404.
         """
         response = self.client.get('/lti_consumer/v1/public_keysets/invalid-key')
         self.assertEqual(response.status_code, 404)

--- a/lti_consumer/tests/unit/plugin/test_views.py
+++ b/lti_consumer/tests/unit/plugin/test_views.py
@@ -27,10 +27,17 @@ class TestLti1p3KeysetEndpoint(TestCase):
 
     def test_public_keyset_endpoint(self):
         """
-        Check that the keyset endpoint works properly.
+        Check that the keyset endpoint maps correctly to the
+        `public_keyset_endpoint` XBlock handler endpoint.
         """
         response = self.client.get(self.url)
+
+        # Check response
         self.assertEqual(response.status_code, 200)
+        # Check function call arguments
+        kwargs = self._mock_xblock_handler.call_args.kwargs
+        self.assertEqual(kwargs['usage_id'], self.location)
+        self.assertEqual(kwargs['handler'], 'public_keyset_endpoint')
 
     def test_invalid_usage_key(self):
         """
@@ -61,14 +68,21 @@ class TestLti1p3LaunchGateEndpoint(TestCase):
 
     def test_launch_gate(self):
         """
-        Check that the launch endpoint works properly.
+        Check that the launch endpoint correctly maps to the
+        `lti_1p3_launch_callback` XBlock handler.
         """
         response = self.client.get(self.url, self.request)
+
+        # Check response
         self.assertEqual(response.status_code, 200)
+        # Check function call arguments
+        kwargs = self._mock_xblock_handler.call_args.kwargs
+        self.assertEqual(kwargs['usage_id'], self.location)
+        self.assertEqual(kwargs['handler'], 'lti_1p3_launch_callback')
 
     def test_invalid_usage_key(self):
         """
-        Check invalid login_hint yields HTTP code 404.
+        Check that passing a invalid login_hint yields HTTP code 404.
         """
         self._mock_xblock_handler.side_effect = Exception()
         response = self.client.get(self.url, self.request)
@@ -95,10 +109,17 @@ class TestLti1p3AccessTokenEndpoint(TestCase):
 
     def test_access_token_endpoint(self):
         """
-        Check that the keyset endpoint works properly.
+        Check that the keyset endpoint is correctly mapping to the
+        `lti_1p3_access_token` XBlock handler.
         """
         response = self.client.post(self.url)
+
+        # Check response
         self.assertEqual(response.status_code, 200)
+        # Check function call arguments
+        kwargs = self._mock_xblock_handler.call_args.kwargs
+        self.assertEqual(kwargs['usage_id'], self.location)
+        self.assertEqual(kwargs['handler'], 'lti_1p3_access_token')
 
     def test_invalid_usage_key(self):
         """

--- a/test.py
+++ b/test.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', u'workbench.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', u'test_settings')
 
     try:
         from django.conf import settings  # pylint: disable=wrong-import-position

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,0 +1,11 @@
+"""
+Custom testing settings for testing views
+"""
+from workbench.settings import *
+
+
+# Usage id pattern (from edx-platform)
+USAGE_ID_PATTERN = r'(?P<usage_id>(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|(?:[^/]+))'
+
+# Keep settings, use different ROOT_URLCONF
+ROOT_URLCONF = 'test_urls'

--- a/test_urls.py
+++ b/test_urls.py
@@ -1,9 +1,9 @@
 """
 Custom URL patterns for testing
 """
-from django.conf.urls import include, url
+from django.conf.urls import include, re_path
 
 urlpatterns = [
-    url(r'^', include('workbench.urls')),
-    url(r'^', include('lti_consumer.plugin.urls')),
+    re_path(r'^', include('workbench.urls')),
+    re_path(r'^', include('lti_consumer.plugin.urls')),
 ]

--- a/test_urls.py
+++ b/test_urls.py
@@ -1,0 +1,9 @@
+"""
+Custom URL patterns for testing
+"""
+from django.conf.urls import include, url
+
+urlpatterns = [
+    url(r'^', include('workbench.urls')),
+    url(r'^', include('lti_consumer.plugin.urls')),
+]


### PR DESCRIPTION
This PR changes a few settings and allows testing standalone Django endpoints from the plugin implementation.
This also adds basic testing to a few Django views that were missing coverage. 

**Testing instructions:**
1. Clone this repo.
2. Run tests.
3. Since some view related code changed, ideally you need to do a test launch, but since setting up LTI is not that easy, test one of the endpoints and make sure it's working.

_To test the keyset endpoint:_
1. Set this feature flag in Studio:
```
FEATURES:
    LTI_1P3_ENABLED: true
```
2. Restart the LMS, create a course and add `lti_consumer` to advanced modules list.
3. Add the LTI Block, edit it, and set it to use LTI 1.3. Save.
4. Look at the preview in Studio, copy the Keyset URL and check that it works.

**Note:**
I've tested a full LTI launch and it's working properly.

**Reviewers:**
- [x] @aayushagra
- [ ] @davidjoy 
- [ ] @nedbat 