### PR TITLE
TNL-7608 - Add Note about ngrok usage.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,12 @@ Instructions:
 8. Publish block, log into LMS and navigate to the LTI block page.
 9. Click ``Send Request`` and verify that the LTI launch was successful.
 
+.. admonition:: Testing using ``ngrok``
+
+    When launching LTI 1.3 requests through ``ngrok``, make sure you set ``DCS_SESSION_COOKIE_SAMESITE = 'None'`` in your
+    ``devstack.py`` (located in /edx/app/edxapp/edx-platform/(lms|cms)/envs``) when doing LTI 1.3 launches in the
+    devstack through ngrok. Do not forget to restart your services after updating the ``.py`` files.
+
 Custom LTI Parameters
 ---------------------
 This XBlock sends a number of parameters to the provider including some optional parameters. To keep the XBlock


### PR DESCRIPTION
As stated by @giovannicimolin:

> 

>Due to a recent change in [Chrome](https://twitter.com/ChromiumDev/status/1293236234932846596) and [Firefox](https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/)
and the way they handle cookies, it’s not possible
to access cookies marked as ``SameSite=None`` if
they are not also Secure.
This is to help avoid a few CSRF attacks.
Secure cookies are only available when the request
is done through [HTTPS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) (see `Secure` attribute), which is not the case on
the devstack.

The workaround for this behaviour is to set
`DCS_SESSION_COOKIE_SAMESITE` from `'Lax'`
to `None` in the studio container's `devstack.py`,
when using tools such as `ngrok`.

This commit adds a note about this to the `README.rst`
of the repository.