### PR TITLE
[BD-24] [BB-3161] LTI launch as a regular Django endpoint

### DIFF
--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -25,5 +25,6 @@ def has_access(*args, **kwargs):
     """
     Import and run the `has_access` method from courseware module.
     """
-    from lms.djangoapps.courseware.access import has_access
-    return has_access(*args, **kwargs)
+    # pylint: disable=import-error,import-outside-toplevel
+    from lms.djangoapps.courseware.access import has_access as course_has_access
+    return course_has_access(*args, **kwargs)

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -19,3 +19,11 @@ def run_xblock_handler_noauth(*args, **kwargs):
     # pylint: disable=import-error,import-outside-toplevel
     from lms.djangoapps.courseware.module_render import handle_xblock_callback_noauth
     return handle_xblock_callback_noauth(*args, **kwargs)
+
+
+def has_access(*args, **kwargs):
+    """
+    Import and run the `has_access` method from courseware module.
+    """
+    from lms.djangoapps.courseware.access import has_access
+    return has_access(*args, **kwargs)

--- a/lti_consumer/plugin/urls.py
+++ b/lti_consumer/plugin/urls.py
@@ -11,6 +11,7 @@ from rest_framework import routers
 
 from lti_consumer.plugin.views import (
     public_keyset_endpoint,
+    lti_1p3_launch_start,
     launch_gate_endpoint,
     access_token_endpoint,
     # LTI Advantage URLs
@@ -34,6 +35,11 @@ urlpatterns = [
         'lti_consumer/v1/launch/(?:/(?P<suffix>.*))?$',
         launch_gate_endpoint,
         name='lti_consumer.launch_gate'
+    ),
+    url(
+        'lti_consumer/v1/launch_start/{}$'.format(settings.USAGE_ID_PATTERN),
+        lti_1p3_launch_start,
+        name='lti_consumer.launch_start'
     ),
     url(
         'lti_consumer/v1/token/{}$'.format(settings.USAGE_ID_PATTERN),

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -43,6 +43,16 @@ def get_lms_lti_keyset_link(location):
     )
 
 
+def get_runtime_environment():
+    """
+    Returns the runtime
+    """
+    if settings.ROOT_URLCONF == 'lms.urls':
+        return "lms"
+
+    return "studio"
+
+
 def get_lms_lti_launch_link():
     """
     Returns an LMS link to LTI Launch endpoint


### PR DESCRIPTION
This PR adds  LTI launch as a regular Django endpoint with proper access control so that it can be used from anywhere and not limited to XBlock.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3161

~~**Discussions**:~~

**Dependencies**: None

~~**Screenshots**:~~

~~**Sandbox URL**:~~

**Merge deadline**: None

**Testing instructions**:

1. Pull this PR
2. Add a ``lti_consumer`` block and test that it works correctly.
2. Visit ``http://localhost:18000/api/lti_consumer/v1/launch_start/[usage_key]`` to see LTI launch from newly developed endpoint.

**Author notes and concerns**:
N/A

**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD

~~**Settings**~~