### PR TITLE
[BD-24] [TNL-7661] [BB-3172] LTI Improvements - Use declarative grading model on XBlock launch

### DIFF
--- a/lti_consumer/admin.py
+++ b/lti_consumer/admin.py
@@ -2,7 +2,7 @@
 Admin views for LTI related models.
 """
 from django.contrib import admin
-from lti_consumer.models import LtiAgsLineItem, LtiConfiguration
+from lti_consumer.models import LtiAgsLineItem, LtiConfiguration, LtiAgsScore
 
 
 class LtiConfigurationAdmin(admin.ModelAdmin):
@@ -16,3 +16,4 @@ class LtiConfigurationAdmin(admin.ModelAdmin):
 
 admin.site.register(LtiConfiguration, LtiConfigurationAdmin)
 admin.site.register(LtiAgsLineItem)
+admin.site.register(LtiAgsScore)

--- a/lti_consumer/apps.py
+++ b/lti_consumer/apps.py
@@ -25,3 +25,7 @@ class LTIConsumerApp(AppConfig):
             }
         }
     }
+
+    def ready(self):
+        # pylint: disable=unused-import,import-outside-toplevel
+        import lti_consumer.signals

--- a/lti_consumer/lti_1p3/ags.py
+++ b/lti_consumer/lti_1p3/ags.py
@@ -72,8 +72,6 @@ class LtiAgs:
         if self.lineitem_url:
             claim_values["lineitem"] = self.lineitem_url
 
-        ags_claim = {
+        return {
             "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint": claim_values,
         }
-
-        return ags_claim

--- a/lti_consumer/lti_1p3/ags.py
+++ b/lti_consumer/lti_1p3/ags.py
@@ -19,6 +19,7 @@ class LtiAgs:
     def __init__(
         self,
         lineitems_url,
+        lineitem_url,
         allow_creating_lineitems=True,
         results_service_enabled=True,
         scores_service_enabled=True
@@ -36,6 +37,8 @@ class LtiAgs:
 
         # Lineitems urls
         self.lineitems_url = lineitems_url
+
+        self.lineitem_url = lineitem_url
 
     def get_available_scopes(self):
         """

--- a/lti_consumer/lti_1p3/ags.py
+++ b/lti_consumer/lti_1p3/ags.py
@@ -18,7 +18,7 @@ class LtiAgs:
     """
     def __init__(
         self,
-        lineitems_url=None,
+        lineitems_url,
         lineitem_url=None,
         allow_creating_lineitems=True,
         results_service_enabled=True,
@@ -63,11 +63,17 @@ class LtiAgs:
         """
         Returns LTI AGS Claim to be injected in the LTI launch message.
         """
+
+        claim_values = {
+            "scope": self.get_available_scopes(),
+            "lineitems": self.lineitems_url,
+        }
+
+        if self.lineitem_url:
+            claim_values["lineitem"] = self.lineitem_url
+
         ags_claim = {
-            "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint": {
-                "scope": self.get_available_scopes(),
-                "lineitems": self.lineitems_url,
-            }
+            "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint": claim_values
         }
 
         return ags_claim

--- a/lti_consumer/lti_1p3/ags.py
+++ b/lti_consumer/lti_1p3/ags.py
@@ -18,8 +18,8 @@ class LtiAgs:
     """
     def __init__(
         self,
-        lineitems_url,
-        lineitem_url,
+        lineitems_url=None,
+        lineitem_url=None,
         allow_creating_lineitems=True,
         results_service_enabled=True,
         scores_service_enabled=True

--- a/lti_consumer/lti_1p3/ags.py
+++ b/lti_consumer/lti_1p3/ags.py
@@ -73,7 +73,7 @@ class LtiAgs:
             claim_values["lineitem"] = self.lineitem_url
 
         ags_claim = {
-            "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint": claim_values
+            "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint": claim_values,
         }
 
         return ags_claim

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -474,7 +474,7 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
 
     def enable_ags(
         self,
-        lineitems_url=None,
+        lineitems_url,
         lineitem_url=None,
         allow_programatic_grade_interaction=False
     ):

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -474,9 +474,9 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
 
     def enable_ags(
         self,
-        lineitems_url,
-        lineitem_url,
-        ags_interaction_model='programmatic'
+        lineitems_url=None,
+        lineitem_url=None,
+        allow_programatic_grade_interaction=False
     ):
         """
         Enable LTI Advantage Assignments and Grades Service.
@@ -485,12 +485,10 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
         and set up the required class.
         """
 
-        allow_creating_lineitems = ags_interaction_model == 'programmatic'
-
         self.ags = LtiAgs(
             lineitems_url=lineitems_url,
             lineitem_url=lineitem_url,
-            allow_creating_lineitems=allow_creating_lineitems,
+            allow_creating_lineitems=allow_programatic_grade_interaction,
             results_service_enabled=True,
             scores_service_enabled=True
         )

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -475,6 +475,8 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
     def enable_ags(
         self,
         lineitems_url,
+        lineitem_url,
+        ags_interaction_model='programmatic'
     ):
         """
         Enable LTI Advantage Assignments and Grades Service.
@@ -482,9 +484,13 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
         This will include the LTI AGS Claim in the LTI message
         and set up the required class.
         """
+
+        allow_creating_lineitems = ags_interaction_model == 'programmatic'
+
         self.ags = LtiAgs(
             lineitems_url=lineitems_url,
-            allow_creating_lineitems=True,
+            lineitem_url=lineitem_url,
+            allow_creating_lineitems=allow_creating_lineitems,
             results_service_enabled=True,
             scores_service_enabled=True
         )

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -647,7 +647,7 @@ class TestLtiAdvantageConsumer(TestCase):
             {
                 'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint': {
                     'scope': [
-                        'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem',
+                        'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly',
                         'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly',
                         'https://purl.imsglobal.org/spec/lti-ags/scope/score'
                     ],

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -649,9 +649,9 @@ class TestLtiAdvantageConsumer(TestCase):
                     'scope': [
                         'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly',
                         'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly',
-                        'https://purl.imsglobal.org/spec/lti-ags/scope/score'
+                        'https://purl.imsglobal.org/spec/lti-ags/scope/score',
                     ],
-                    'lineitems': 'http://example.com/lineitems'
+                    'lineitems': 'http://example.com/lineitems',
                 }
             }
         )

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -314,7 +314,7 @@ class LtiAgsScore(models.Model):
 
 
 @receiver(post_save, sender=LtiAgsScore)
-def update_student_grade(sender, instance, **kwargs):
+def update_student_grade(sender, instance, **kwargs):  # pylint: disable=unused-argument
     """
     Submit grade to xblock whenever score saved/updated and its
     grading_progress is set to FullyGraded.

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -71,12 +71,6 @@ def get_user_from_external_user_id(external_user_id):
         raise LtiError('Invalid userID') from exception
 
 
-def load_block(key):
-    # pylint: disable=import-outside-toplevel,import-error
-    from xmodule.modulestore.django import modulestore
-    return modulestore().get_item(key)
-
-
 def publish_grade(block, user, score, possible, only_if_higher=False, score_deleted=None, comment=None):
     """
     Import grades signals and publishes score by triggering SCORE_PUBLISHED signal.

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -49,3 +49,15 @@ def load_block_as_anonymous_user(location):
     )
 
     return descriptor
+
+
+def get_user_from_external_user_id(external_user_id):
+    """
+    Import ExternalId model and find user by external_user_id
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from openedx.core.djangoapps.external_user_ids.models import ExternalId
+    return ExternalId.objects.get(
+        external_user_id=external_user_id,
+        external_id_type__name='lti'
+    ).user

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -25,7 +25,7 @@ def run_xblock_handler_noauth(*args, **kwargs):
 
 def load_block_as_anonymous_user(location):
     """
-    Load a block as an user if given, else anonymous user.
+    Load a block as anonymous user.
 
     This uses a few internal courseware methods to retrieve the descriptor
     and bind an AnonymousUser to it, in a similar fashion as a `noauth` XBlock

--- a/lti_consumer/signals.py
+++ b/lti_consumer/signals.py
@@ -16,7 +16,7 @@ def publish_grade_on_score_update(sender, instance, **kwargs):  # pylint: disabl
     """
     if instance.grading_progress == LtiAgsScore.FULLY_GRADED:
         block = compat.load_block_as_anonymous_user(instance.line_item.resource_link_id)
-        if not block.is_past_due():
+        if not block.is_past_due() or block.accept_grades_past_due:
             user = compat.get_user_from_external_user_id(instance.user_id)
             compat.publish_grade(
                 block,

--- a/lti_consumer/signals.py
+++ b/lti_consumer/signals.py
@@ -18,10 +18,12 @@ def publish_grade_on_score_update(sender, instance, **kwargs):  # pylint: disabl
         block = compat.load_block_as_anonymous_user(instance.line_item.resource_link_id)
         if not block.is_past_due() or block.accept_grades_past_due:
             user = compat.get_user_from_external_user_id(instance.user_id)
+            # check if score_given is larger than score_maximum
+            score = instance.score_given if instance.score_given < instance.score_maximum else instance.score_maximum
             compat.publish_grade(
                 block,
                 user,
-                instance.score_given,
+                score,
                 instance.score_maximum,
                 comment=instance.comment
             )

--- a/lti_consumer/signals.py
+++ b/lti_consumer/signals.py
@@ -1,0 +1,31 @@
+"""
+LTI Consumer related Signal handlers
+"""
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from lti_consumer.models import LtiAgsScore
+from lti_consumer.plugin.compat import (
+    publish_grade,
+    load_block,
+    get_user_from_external_user_id,
+)
+
+
+@receiver(post_save, sender=LtiAgsScore, dispatch_uid='publish_grade_on_score_update')
+def publish_grade_on_score_update(sender, instance, **kwargs):  # pylint: disable=unused-argument
+    """
+    Publish grade to xblock whenever score saved/updated and its grading_progress is set to FullyGraded.
+    """
+    if instance.grading_progress == LtiAgsScore.FULLY_GRADED:
+        block = load_block(instance.line_item.resource_link_id)
+        if not block.is_past_due():
+            user = get_user_from_external_user_id(instance.user_id)
+            publish_grade(
+                block,
+                user,
+                instance.score_given,
+                instance.score_maximum,
+                comment=instance.comment
+            )

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -470,6 +470,27 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         self._compat_mock.get_user_from_external_user_id.assert_not_called()
         self._compat_mock.publish_grade.assert_not_called()
 
+    @patch('lti_consumer.lti_xblock.timezone')
+    def test_xblock_grade_publish_accept_passed_due_date(self, timezone_patcher):
+        """
+        Test grade publish after due date when accept_grades_past_due is True. Grade should publish.
+        """
+        xblock_attrs = {
+            'accept_grades_past_due': True
+        }
+        xblock_attrs.update(self.xblock_attributes)
+        xblock = make_xblock('lti_consumer', LtiConsumerXBlock, xblock_attrs)
+        self._compat_mock.load_block_as_anonymous_user.return_value = xblock
+
+        timezone_patcher.now.return_value = timezone.now() + timedelta(days=30)
+
+        self._post_lti_score()
+
+        self._compat_mock.load_block_as_anonymous_user.assert_called_once()
+
+        self._compat_mock.get_user_from_external_user_id.assert_not_called()
+        self._compat_mock.publish_grade.assert_not_called()
+
     def test_create_multiple_scores_with_multiple_users(self):
         """
         Test the LTI AGS LineItem Score Creation on the same LineItem for different users.

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -456,6 +456,23 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
             self._compat_mock.get_user_from_external_user_id.assert_not_called()
             self._compat_mock.publish_grade.assert_not_called()
 
+    def test_grade_publish_score_bigger_than_maximum(self):
+        """
+        Test when given score is bigger than maximum score.
+        """
+        self._post_lti_score({
+            "scoreGiven": 110,
+            "scoreMaximum": 100,
+        })
+        score = LtiAgsScore.objects.get(line_item=self.line_item, user_id=self.primary_user_id)
+
+        self._compat_mock.publish_grade.assert_called_once()
+
+        call_args = self._compat_mock.publish_grade.call_args.args
+
+        # as score_given is larger than score_maximum, it should pass score_maximum as given score
+        self.assertEqual(call_args, (self.xblock, self._mock_user, score.score_maximum, score.score_maximum,))
+
     @patch('lti_consumer.lti_xblock.timezone')
     def test_xblock_grade_publish_passed_due_date(self, timezone_patcher):
         """

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -159,11 +159,14 @@ class TestLtiAgsScoreModel(TestCase):
     Unit tests for LtiAgsScore model methods.
     """
 
-    @patch("lti_consumer.signals.compat")
-    def setUp(self, compat_mock):
+    def setUp(self):
         super().setUp()
 
-        compat_mock.load_block_as_anonymous_user.return_value = make_xblock(
+        # patch things related to LtiAgsScore post_save signal receiver
+        compat_mock = patch("lti_consumer.signals.compat")
+        self.addCleanup(compat_mock.stop)
+        self._compat_mock = compat_mock.start()
+        self._compat_mock.load_block_as_anonymous_user.return_value = make_xblock(
             'lti_consumer', LtiConsumerXBlock, {}, MagicMock(return_value=False)
         )
 

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -1,11 +1,13 @@
 """
 Unit tests for LTI models.
 """
+from datetime import timedelta
 from Cryptodome.PublicKey import RSA
+from django.utils import timezone
 from django.test.testcases import TestCase
 
 from jwkest.jwk import RSAKey
-from mock import patch, MagicMock
+from mock import patch
 
 from lti_consumer.lti_xblock import LtiConsumerXBlock
 from lti_consumer.models import LtiAgsLineItem, LtiConfiguration, LtiAgsScore
@@ -167,7 +169,10 @@ class TestLtiAgsScoreModel(TestCase):
         self.addCleanup(compat_mock.stop)
         self._compat_mock = compat_mock.start()
         self._compat_mock.load_block_as_anonymous_user.return_value = make_xblock(
-            'lti_consumer', LtiConsumerXBlock, {}, MagicMock(return_value=False)
+            'lti_consumer', LtiConsumerXBlock, {
+                'due': timezone.now(),
+                'graceperiod': timedelta(days=2)
+            }
         )
 
         self.dummy_location = 'block-v1:course+test+2020+type@problem+block@test'

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -99,7 +99,7 @@ class TestLtiConfigurationModel(TestCase):
                 'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint':
                 {
                     'scope': [
-                        'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem',
+                        'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly',
                         'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly',
                         'https://purl.imsglobal.org/spec/lti-ags/scope/score',
                     ],
@@ -159,6 +159,13 @@ class TestLtiAgsScoreModel(TestCase):
     """
     def setUp(self):
         super().setUp()
+
+        submit_grade_patcher = patch(
+            'lti_consumer.models.submit_grade',
+            return_value=None
+        )
+        self.addCleanup(submit_grade_patcher.stop)
+        self._submit_block_patch = submit_grade_patcher.start()
 
         self.dummy_location = 'block-v1:course+test+2020+type@problem+block@test'
         self.line_item = LtiAgsLineItem.objects.create(

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -106,7 +106,7 @@ class TestLtiConfigurationModel(TestCase):
                         'https://purl.imsglobal.org/spec/lti-ags/scope/score',
                     ],
                     'lineitems': 'https://example.com/api/lti_consumer/v1/lti/2/lti-ags',
-                    'lineitem': 'https://example.com/api/lti_consumer/v1/lti/2/lti-ags/1'
+                    'lineitem': 'https://example.com/api/lti_consumer/v1/lti/2/lti-ags/1',
                 }
             }
         )
@@ -171,7 +171,7 @@ class TestLtiAgsScoreModel(TestCase):
         self._compat_mock.load_block_as_anonymous_user.return_value = make_xblock(
             'lti_consumer', LtiConsumerXBlock, {
                 'due': timezone.now(),
-                'graceperiod': timedelta(days=2)
+                'graceperiod': timedelta(days=2),
             }
         )
 

--- a/lti_consumer/tests/unit/test_utils.py
+++ b/lti_consumer/tests/unit/test_utils.py
@@ -11,7 +11,7 @@ from xblock.runtime import DictKeyValueStore, KvsFieldData
 FAKE_USER_ID = 'fake_user_id'
 
 
-def make_xblock(xblock_name, xblock_cls, attributes):
+def make_xblock(xblock_name, xblock_cls, attributes, is_past_due_patch=None):
     """
     Helper to construct XBlock objects
     """
@@ -27,6 +27,11 @@ def make_xblock(xblock_name, xblock_cls, attributes):
     xblock.runtime = Mock(
         hostname='localhost',
     )
+
+    # mock is_past_due method
+    if is_past_due_patch:
+        xblock.is_past_due = is_past_due_patch
+
     xblock.course_id = 'course-v1:edX+DemoX+Demo_Course'
     for key, value in attributes.items():
         setattr(xblock, key, value)

--- a/lti_consumer/tests/unit/test_utils.py
+++ b/lti_consumer/tests/unit/test_utils.py
@@ -11,7 +11,7 @@ from xblock.runtime import DictKeyValueStore, KvsFieldData
 FAKE_USER_ID = 'fake_user_id'
 
 
-def make_xblock(xblock_name, xblock_cls, attributes, is_past_due_patch=None):
+def make_xblock(xblock_name, xblock_cls, attributes):
     """
     Helper to construct XBlock objects
     """
@@ -27,11 +27,6 @@ def make_xblock(xblock_name, xblock_cls, attributes, is_past_due_patch=None):
     xblock.runtime = Mock(
         hostname='localhost',
     )
-
-    # mock is_past_due method
-    if is_past_due_patch:
-        xblock.is_past_due = is_past_due_patch
-
     xblock.course_id = 'course-v1:edX+DemoX+Demo_Course'
     for key, value in attributes.items():
         setattr(xblock, key, value)

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -74,14 +74,13 @@ def get_lti_ags_lineitems_url(lti_config_id, lineitem_id=None):
     :param lineitem_id: LTI Line Item id. Single line item if given an id,
         otherwise returns list url
     """
-    base_ags_url = "{lms_base}/api/lti_consumer/v1/lti/{lti_config_id}/lti-ags".format(
+
+    url = "{lms_base}/api/lti_consumer/v1/lti/{lti_config_id}/lti-ags".format(
         lms_base=get_lms_base(),
         lti_config_id=str(lti_config_id),
     )
 
     if lineitem_id:
-        url = "{url}/{lineitem_id}".format(url=base_ags_url, lineitem_id=lineitem_id)
-    else:
-        url = base_ags_url
+        url += "/" + str(lineitem_id)
 
     return url

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -76,3 +76,17 @@ def get_lti_ags_lineitems_url(lti_config_id):
         lms_base=get_lms_base(),
         lti_config_id=str(lti_config_id),
     )
+
+
+def get_lti_ags_lineitem_url(lti_config_id, lineitem_id):
+    """
+    Return the LTI AGS LineItem endpoint
+
+    :param lti_config_id: LTI configuration id
+    :param lineitem_id: Line Item instance id
+    """
+    return "{lms_base}/api/lti_consumer/v1/lti/{lti_config_id}/lti-ags/{lineitem_id}".format(
+        lms_base=get_lms_base(),
+        lti_config_id=str(lti_config_id),
+        lineitem_id=str(lineitem_id)
+    )

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -74,12 +74,14 @@ def get_lti_ags_lineitems_url(lti_config_id, lineitem_id=None):
     :param lineitem_id: LTI Line Item id. Single line item if given an id,
         otherwise returns list url
     """
-    url = "{lms_base}/api/lti_consumer/v1/lti/{lti_config_id}/lti-ags".format(
+    base_ags_url = "{lms_base}/api/lti_consumer/v1/lti/{lti_config_id}/lti-ags".format(
         lms_base=get_lms_base(),
         lti_config_id=str(lti_config_id),
     )
 
     if lineitem_id:
-        url = "{url}/{lineitem_id}".format(url=url, lineitem_id=lineitem_id)
+        url = "{url}/{lineitem_id}".format(url=base_ags_url, lineitem_id=lineitem_id)
+    else:
+        url = base_ags_url
 
     return url

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -66,27 +66,20 @@ def get_lms_lti_access_token_link(location):
     )
 
 
-def get_lti_ags_lineitems_url(lti_config_id):
+def get_lti_ags_lineitems_url(lti_config_id, lineitem_id=None):
     """
     Return the LTI AGS endpoint
 
     :param lti_config_id: LTI configuration id
+    :param lineitem_id: LTI Line Item id. Single line item if given an id,
+        otherwise returns list url
     """
-    return "{lms_base}/api/lti_consumer/v1/lti/{lti_config_id}/lti-ags".format(
+    url = "{lms_base}/api/lti_consumer/v1/lti/{lti_config_id}/lti-ags".format(
         lms_base=get_lms_base(),
         lti_config_id=str(lti_config_id),
     )
 
+    if lineitem_id:
+        url = "{url}/{lineitem_id}".format(url=url, lineitem_id=lineitem_id)
 
-def get_lti_ags_lineitem_url(lti_config_id, lineitem_id):
-    """
-    Return the LTI AGS LineItem endpoint
-
-    :param lti_config_id: LTI configuration id
-    :param lineitem_id: Line Item instance id
-    """
-    return "{lms_base}/api/lti_consumer/v1/lti/{lti_config_id}/lti-ags/{lineitem_id}".format(
-        lms_base=get_lms_base(),
-        lti_config_id=str(lti_config_id),
-        lineitem_id=str(lineitem_id)
-    )
+    return url


### PR DESCRIPTION
This PR adds support for the declarative grading model for LTI consumer.

**JIRA tickets**: 
- https://openedx.atlassian.net/browse/TNL-7661

~~**Discussions**:~~

**Dependencies**: None

~~**Screenshots**:~~

~~**Sandbox URL**:~~

**Merge deadline**: ASAP

**Testing instructions**:
1. Make sure lti_consumer installed as per [README.rst](https://github.com/edx/xblock-lti-consumer/blob/master/README.rst)
2. Setup a new LTI block with ``Scored = True`` and Set a ``weight`` value.
3. Test if the LTI launch is successful.
4. Go to admin ``/admin/lti_consumer/ltiagslineitem/`` URL and confirm that a Line Item has been generated automatically with correct LTI Configuration, resource id, label, and Maximum Score (``weight``).
5. Generate a JWT token -
    - Go to www.jwt.io
    - select RS-256
    - Fill in both the private and public keys section in the bottom right (use public & private key used during LTI block setup)
    - Set the header and payload as follows
```
# HEADER:
{
  "alg": "RS256",
  "typ": "JWT",
  "kid": "123"
}
# PAYLOAD:
{
  "sub": "1234567890",
  "name": "John Doe",
  "admin": true,
  "iat": 1516239022
}
```
6. Use JWT to get an OIDC token
```
curl --request POST \
  --url 'http://localhost:18000/api/lti_consumer/v1/token/<USAGE_KEY>' \
  --header 'Content-Type: application/x-www-form-urlencoded' \
  --data grant_type=client_credentials \
  --data 'scope=https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly https://purl.imsglobal.org/spec/lti-ags/scope/score https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly' \
  --data client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer \
  --data client_assertion=<JWT_TOKEN>
```
7. Publish score
```
curl --request POST \
  --url http://localhost:18000/api/lti_consumer/v1/lti/1/lti-ags/1/scores \
  --header 'Authorization: Bearer <OIDC_TOKEN>' \
  --header 'Content-Type: application/vnd.ims.lis.v1.score+json' \
  --data '{"timestamp": "2020-09-27T18:54:36.736+00:00","scoreGiven" : 86,"scoreMaximum" : 100,"comment" : "This is exceptional work.","activityProgress" : "Completed","gradingProgress": "FullyGraded","userId" : "<EXTERNAL_ID>"}'
```
8. The published score should be visible in the Progress tab of the course.

**Author notes and concerns**:
1. The signal seems to be called from out of request scope causing ``User`` to be null when loaded by ``django-crum`` module. As per documentation [here](https://github.com/ninemoreminutes/django-crum/blob/eeb350fc963360633b70472f06ddc6201ece5387/docs/index.rst#get_current_user) it returns ``user=None`` when not in request scope. I couldn't figure out why xblock signal is outside the request scope, when some other places seems to be working fine like [here](https://github.com/edx/edx-platform/blob/9cf2f9f298e5e8be3b3abcaadaf0b7a96d0de0df/common/djangoapps/course_modes/signals.py#L65).

Anyhow, I fixed the issue by [impersonating](https://github.com/ninemoreminutes/django-crum/blob/eeb350fc963360633b70472f06ddc6201ece5387/docs/index.rst#impersonateusernone) as ``AnonymousUser`` [here](https://github.com/open-craft/xblock-lti-consumer/blob/09c1e0a310ac5a1971dc1177334086762bee5971/lti_consumer/plugin/compat.py#L46). But I'm not sure if this is the right way to do it.
 
**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD

~~**Settings**~~