### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -284,8 +284,8 @@ License
 The LTI Consumer XBlock is available under the AGPL v3 License.
 
 
-.. |Build Status| image:: https://travis-ci.org/edx/xblock-lti-consumer.svg
-  :target: https://travis-ci.org/edx/xblock-lti-consumer
+.. |Build Status| image:: https://travis-ci.com/edx/xblock-lti-consumer.svg
+  :target: https://travis-ci.com/edx/xblock-lti-consumer
 
 .. |Coveralls| image:: https://coveralls.io/repos/edx/xblock-lti-consumer/badge.svg?branch=master&service=github
   :target: https://coveralls.io/github/edx/xblock-lti-consumer?branch=master


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089 