### PR TITLE
[BD-24] [BB-3245] LTI 1.3 Studio preview window

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -896,6 +896,10 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         # Retrieve LTI 1.3 Launch information
         context.update(get_lti_1p3_launch_info(block=self))
 
+        context.update({
+            'published': self.runtime.modulestore.has_published_version(self)
+        })
+
         # Render template
         fragment = Fragment()
         loader = ResourceLoader(__name__)

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -897,7 +897,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         context.update(get_lti_1p3_launch_info(block=self))
 
         context.update({
-            'published': self.runtime.modulestore.has_published_version(self)
+            'launch_preview_url': self.runtime.handler_url(self, 'lti_1p3_launch_handler').rstrip('/?')
         })
 
         # Render template

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -118,5 +118,12 @@ function LtiConsumerXBlock(runtime, element) {
                 window.open($(this).data('target'));
             }
         });
+
+        // studio launch - on button click set launch url to iframe and display it
+        $element.find('.btn-lti-studio-launch').click(function(){
+            $iframe = $element.find('.ltiLaunchFrame')
+            $iframe.attr('src', runtime.handlerUrl(element, 'lti_1p3_launch_handler'))
+            $iframe.css('display', 'block')
+        })
     });
 }

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -118,12 +118,5 @@ function LtiConsumerXBlock(runtime, element) {
                 window.open($(this).data('target'));
             }
         });
-
-        // studio launch - on button click set launch url to iframe and display it
-        $element.find('.btn-lti-studio-launch').click(function(){
-            $iframe = $element.find('.ltiLaunchFrame')
-            $iframe.attr('src', runtime.handlerUrl(element, 'lti_1p3_launch_handler'))
-            $iframe.css('display', 'block')
-        })
     });
 }

--- a/lti_consumer/templates/html/lti_1p3_studio.html
+++ b/lti_consumer/templates/html/lti_1p3_studio.html
@@ -49,6 +49,7 @@
             <b>Test LTI Launch: </b>
 
             <button
+                class="test-launch-button"
                 onclick="window.open('${launch_preview_url}')"
                 aria-disabled="false"
                 title="LTI 1.3 Test Launch"

--- a/lti_consumer/templates/html/lti_1p3_studio.html
+++ b/lti_consumer/templates/html/lti_1p3_studio.html
@@ -47,22 +47,17 @@
         </p>
         <p>
             <b>Test LTI Launch: </b>
-            % if published:
-            <button class="btn btn-secondary" type="button">Test Launch</button>
-            % else:
-            The launch only works if the block is published.
-            % endif
+
+            <a
+                href="${launch_preview_url}"
+                class="test-launch-button"
+                rel="noopener external"
+                target="_blank"
+                aria-disabled="false"
+                title="LTI 1.3 Test Launch"
+            >
+                Test Launch
+            </a> - The launch only works if the block is published.
         </p>
-        % if published:
-        <iframe
-            class="ltiLaunchFrame"
-            style="width: 100%; min-height: 400px; display: none;"
-            src="about:blank"
-            allowfullscreen="true"
-            webkitallowfullscreen="true"
-            mozallowfullscreen="true"
-            allow="microphone *; camera *; midi *; geolocation *; encrypted-media *"
-        ></iframe>
-        % endif
     </body>
 </html>

--- a/lti_consumer/templates/html/lti_1p3_studio.html
+++ b/lti_consumer/templates/html/lti_1p3_studio.html
@@ -48,16 +48,14 @@
         <p>
             <b>Test LTI Launch: </b>
 
-            <a
-                href="${launch_preview_url}"
-                class="test-launch-button"
-                rel="noopener external"
-                target="_blank"
+            <button
+                onclick="window.open('${launch_preview_url}')"
                 aria-disabled="false"
                 title="LTI 1.3 Test Launch"
+                type="button"
             >
                 Test Launch
-            </a> - The launch only works if the block is published.
+            </button> - The launch only works if the block is published.
         </p>
     </body>
 </html>

--- a/lti_consumer/templates/html/lti_1p3_studio.html
+++ b/lti_consumer/templates/html/lti_1p3_studio.html
@@ -45,5 +45,24 @@
             <b>OIDC Callback URL: </b>
             ${oidc_callback}
         </p>
+        <p>
+            <b>Test LTI Launch: </b>
+            % if published:
+            <button class="btn btn-secondary" type="button">Test Launch</button>
+            % else:
+            The launch only works if the block is published.
+            % endif
+        </p>
+        % if published:
+        <iframe
+            class="ltiLaunchFrame"
+            style="width: 100%; min-height: 400px; display: none;"
+            src="about:blank"
+            allowfullscreen="true"
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+            allow="microphone *; camera *; midi *; geolocation *; encrypted-media *"
+        ></iframe>
+        % endif
     </body>
 </html>

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1308,19 +1308,10 @@ class TestLtiConsumer1p3XBlock(TestCase):
 
         mock_has_published_version = self.xblock.runtime.modulestore.has_published_version
 
-        # launch can't be performed when not published
         mock_has_published_version.return_value = False
         response = self.xblock.author_view({})
         self.assertIn('The launch only works if the block is published', response.content)
-        self.assertNotIn('ltiLaunchFrame', response.content)
-        self.assertNotIn('btn-lti-studio-launch', response.content)
-
-        # launch can be performed when published
-        mock_has_published_version.return_value = True
-        response = self.xblock.author_view({})
-        self.assertNotIn('The launch only works if the block is published', response.content)
-        self.assertIn('ltiLaunchFrame', response.content)
-        self.assertIn('btn-lti-studio-launch', response.content)
+        self.assertIn('test-launch-button', response.content)
 
 
 class TestLti1p3AccessTokenEndpoint(TestLtiConsumerXBlock):

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1293,6 +1293,35 @@ class TestLtiConsumer1p3XBlock(TestCase):
         self.assertIn("mock-keyset_url", response.content)
         self.assertIn("mock-token_url", response.content)
 
+    @patch('lti_consumer.api.get_lti_1p3_launch_info')
+    def test_author_view_lti_1p3_launch(self, mock_get_launch_info):
+        """
+        Test that LTI 1.3 launch can be performed from studio view.
+        """
+        mock_get_launch_info.return_value = {
+            'client_id': "mock-client_id",
+            'keyset_url': "mock-keyset_url",
+            'deployment_id': '1',
+            'oidc_callback': "mock-oidc_callback",
+            'token_url': "mock-token_url",
+        }
+
+        mock_has_published_version = self.xblock.runtime.modulestore.has_published_version
+
+        # launch can't be performed when not published
+        mock_has_published_version.return_value = False
+        response = self.xblock.author_view({})
+        self.assertIn('The launch only works if the block is published', response.content)
+        self.assertNotIn('ltiLaunchFrame', response.content)
+        self.assertNotIn('btn-lti-studio-launch', response.content)
+
+        # launch can be performed when published
+        mock_has_published_version.return_value = True
+        response = self.xblock.author_view({})
+        self.assertNotIn('The launch only works if the block is published', response.content)
+        self.assertIn('ltiLaunchFrame', response.content)
+        self.assertIn('btn-lti-studio-launch', response.content)
+
 
 class TestLti1p3AccessTokenEndpoint(TestLtiConsumerXBlock):
     """


### PR DESCRIPTION
This PR adds a new ``Test Launch`` link on LTI author view in Studio. Clicking on that link performs an LTI launch in a new window.

**JIRA tickets**:  https://tasks.opencraft.com/browse/BB-3245

~~**Discussions**: ~~

**Dependencies**: None

**Screenshots**: 

![lti_preview](https://user-images.githubusercontent.com/1010244/99502516-607cc900-29a7-11eb-9780-e8bcdbc80104.png)

~~**Sandbox URL**:~~

**Merge deadline**: None

**Testing instructions**:

1. Install [xblock-lti-consumer](https://github.com/edx/xblock-lti-consumer) on local devstack.
2. Make sure LTI 1.3 enabled by setting the feature flag on ``studio.yml``
```
FEATURES:
    LTI_1P3_ENABLED: true
```
3. Create an LTI 1.3 block. Follow the procedure from [here](https://github.com/edx/xblock-lti-consumer#lti-13).
4. Verify that ``Test Launch`` link visible.
5. After publishing, click the ``Test Launch`` link. It should open a new window and perform an LTI launch.

**Author notes and concerns**:

1. I've tried to do it within an iframe. But the launch couldn't be performed as LMS is not of the same origin, thus not loaded inside iframe during auth flow. So I found it easier to open it on a new window instead.

**Reviewers**
- [ ] @viadanna 
- [ ] edX reviewer[s] TBD

~~**Settings**~~
