### PR TITLE
[BD-24] [TNL-7661] [BB-3172] Bump up the version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,8 +298,8 @@ Please do not report security issues in public. Send security concerns via email
 Changelog
 =========
 
-Unreleased
-----------
+2.4 - 2020-12-01
+----------------
 
 * Partially implemented the Assignment and Grades Service to enable tools
   reporting grades back.  Tools cannot create new LineItems.

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='2.3.2',
+    version='2.4.0',
     description='This XBlock implements the consumer side of the LTI specification.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR changes ``xblock-lti-consumer`` version from ``2.3.2`` to ``2.4.0`` as part of previously merged PR #116 

**JIRA tickets**:  https://openedx.atlassian.net/browse/TNL-7661
**Discussions**: https://github.com/edx/xblock-lti-consumer/pull/116#issuecomment-734426488

**Dependencies**: None

~~**Screenshots**:~~ 

~~**Sandbox URL**:~~

**Merge deadline**: None

**Testing instructions**:

1. Check if the version changed from ``2.3.2`` to ``2.4.0`` in ``setup.py``.

**Author notes and concerns**:
N/A

**Reviewers**
- [ ] @giovannicimolin 
- [ ] @nedbat 

~~**Settings**~~