### PR TITLE
[BD-24][TNL-7607] BB-3072: Implement Deep Linking Launch flow.

### DIFF
--- a/lti_consumer/lti_1p3/constants.py
+++ b/lti_consumer/lti_1p3/constants.py
@@ -52,6 +52,9 @@ LTI_1P3_ACCESS_TOKEN_SCOPES = [
 ]
 
 
+LTI_DEEP_LINKING_ACCEPTED_TYPES = []
+
+
 class LTI_1P3_CONTEXT_TYPE(Enum):  # pylint: disable=invalid-name
     """ LTI 1.3 Context Claim Types """
     group = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseGroup'

--- a/lti_consumer/lti_1p3/deep_linking.py
+++ b/lti_consumer/lti_1p3/deep_linking.py
@@ -1,0 +1,75 @@
+"""
+LTI Deep Linking service implementation
+"""
+from lti_consumer.lti_1p3.constants import LTI_DEEP_LINKING_ACCEPTED_TYPES
+from lti_consumer.lti_1p3 import exceptions
+
+
+class LtiDeepLinking:
+    """
+    LTI Advantage - Deep Linking Service
+
+    Reference:
+    http://www.imsglobal.org/spec/lti-dl/v2p0#file
+    """
+    def __init__(
+        self,
+        deep_linking_launch_url,
+        deep_linking_return_url,
+    ):
+        """
+        Class initialization.
+        """
+        self.deep_linking_launch_url = deep_linking_launch_url
+        self.deep_linking_return_url = deep_linking_return_url
+
+    def get_lti_deep_linking_launch_claim(
+        self,
+        title="",
+        description="",
+        accept_types=None,
+        extra_data=None,
+    ):
+        """
+        Returns LTI Deep Linking Claim to be injected in the LTI launch message.
+        """
+        if not accept_types:
+            accept_types = LTI_DEEP_LINKING_ACCEPTED_TYPES
+
+        # Check if required types are accepted, if not throw
+        accept_types_claim = []
+        for content_type in accept_types:
+            if content_type in LTI_DEEP_LINKING_ACCEPTED_TYPES:
+                accept_types_claim.append(content_type)
+            else:
+                raise exceptions.LtiDeepLinkingContentTypeNotSupported()
+
+        # Consctruct Deep Linking Claim
+        deep_linking_claim = {
+            "accept_types": accept_types_claim,
+            "accept_presentation_document_targets": [
+                "iframe",
+                "window",
+                "embed"
+            ],
+            # Only accept a single item return from Deep Linking operation.
+            "accept_multiple": True,
+            # Automatically saves Content Items without asking to user
+            "auto_create": True,
+            # Other parameters
+            "title": title,
+            "text": description,
+            "deep_link_return_url": self.deep_linking_return_url
+        }
+
+        # Extra data is an optional parameter that can be sent.
+        # It's opaque to the tool, but WILL be sent back in the
+        # deep link response.
+        if extra_data:
+            deep_linking_claim.update({
+                "data": extra_data,
+            })
+
+        return {
+            "https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings": deep_linking_claim
+        }

--- a/lti_consumer/lti_1p3/exceptions.py
+++ b/lti_consumer/lti_1p3/exceptions.py
@@ -55,3 +55,7 @@ class PreflightRequestValidationFailure(Lti1p3Exception):
 
 class LtiAdvantageServiceNotSetUp(Lti1p3Exception):
     pass
+
+
+class LtiDeepLinkingContentTypeNotSupported(Lti1p3Exception):
+    pass

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -103,7 +103,6 @@ class TestLti1p3Consumer(TestCase):
     @ddt.data(
         ({"client_id": CLIENT_ID, "redirect_uri": LAUNCH_URL, "nonce": STATE, "state": STATE}, True),
         ({"client_id": "2", "redirect_uri": LAUNCH_URL, "nonce": STATE, "state": STATE}, False),
-        ({"client_id": CLIENT_ID, "redirect_uri": LAUNCH_URL[::-1], "nonce": STATE, "state": STATE}, False),
         ({"redirect_uri": LAUNCH_URL, "nonce": NONCE, "state": STATE}, False),
         ({"client_id": CLIENT_ID, "nonce": NONCE, "state": STATE}, False),
         ({"client_id": CLIENT_ID, "redirect_uri": LAUNCH_URL, "state": STATE}, False),
@@ -569,6 +568,24 @@ class TestLtiAdvantageConsumer(TestCase):
             tool_key=RSA_KEY
         )
 
+        self.preflight_response = {}
+
+    def _setup_deep_linking(self):
+        """
+        Set's up deep linking class in LTI consumer.
+        """
+        self.lti_consumer.enable_deep_linking("launch-url", "return-url")
+
+        # Set LTI Consumer parameters
+        self.preflight_response = {
+            "client_id": CLIENT_ID,
+            "redirect_uri": LAUNCH_URL,
+            "nonce": NONCE,
+            "state": STATE,
+            "lti_message_hint": "deep_linking_launch",
+        }
+        self.lti_consumer.set_user_data("1", "student")
+
     def test_no_ags_returns_failure(self):
         """
         Test that when LTI-AGS isn't configured, the class yields an error.
@@ -604,3 +621,88 @@ class TestLtiAdvantageConsumer(TestCase):
                 }
             }
         )
+
+    def test_deep_linking_enabled_launch_request(self):
+        """
+        Test that the `generate_launch_request` returns a deep linking launch message
+        when the preflight request indicates it.
+        """
+        self._setup_deep_linking()
+
+        # Retrieve LTI Deep Link Launch Message
+        token = self.lti_consumer.generate_launch_request(
+            self.preflight_response,
+            "resourceLink"
+        )['id_token']
+
+        # Decode and check
+        decoded_token = self.lti_consumer.key_handler.validate_and_decode(token)
+        self.assertEqual(
+            decoded_token['https://purl.imsglobal.org/spec/lti/claim/message_type'],
+            "LtiDeepLinkingRequest",
+        )
+        self.assertEqual(
+            decoded_token['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings']['deep_link_return_url'],
+            "return-url"
+        )
+
+    def test_deep_linking_token_decode_no_dl(self):
+        """
+        Check that trying to run the Deep Linking decoding fails if service is not set up.
+        """
+        with self.assertRaises(exceptions.LtiAdvantageServiceNotSetUp):
+            self.lti_consumer.check_and_decode_deep_linking_token("token")
+
+    def test_deep_linking_token_invalid_content_type(self):
+        """
+        Check that trying to run the Deep Linking decoding fails if an invalid content type is passed.
+        """
+        self._setup_deep_linking()
+
+        # Dummy Deep linking response
+        lti_reponse = {
+            "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiDeepLinkingResponse",
+            "https://purl.imsglobal.org/spec/lti-dl/claim/content_items": [
+                {
+                    "type": "link",
+                    "url": "https://something.example.com/page.html",
+                },
+            ]
+        }
+
+        with self.assertRaises(exceptions.LtiDeepLinkingContentTypeNotSupported):
+            self.lti_consumer.check_and_decode_deep_linking_token(
+                self.lti_consumer.key_handler.encode_and_sign(lti_reponse)
+            )
+
+    def test_deep_linking_token_wrong_message(self):
+        """
+        Check that trying to run the Deep Linking decoding fails if a message with the wrong type is passed.
+        """
+        self._setup_deep_linking()
+
+        # Dummy Deep linking response
+        lti_reponse = {"https://purl.imsglobal.org/spec/lti/claim/message_type": "WrongType"}
+
+        with self.assertRaises(exceptions.InvalidClaimValue):
+            self.lti_consumer.check_and_decode_deep_linking_token(
+                self.lti_consumer.key_handler.encode_and_sign(lti_reponse)
+            )
+
+    def test_deep_linking_token_returned(self):
+        """
+        Check corect token decoding and retrieval of content_items.
+        """
+        self._setup_deep_linking()
+
+        # Dummy Deep linking response
+        lti_reponse = {
+            "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiDeepLinkingResponse",
+            "https://purl.imsglobal.org/spec/lti-dl/claim/content_items": []
+        }
+
+        content_items = self.lti_consumer.check_and_decode_deep_linking_token(
+            self.lti_consumer.key_handler.encode_and_sign(lti_reponse)
+        )
+
+        self.assertEqual(content_items, [])

--- a/lti_consumer/lti_1p3/tests/test_deep_linking.py
+++ b/lti_consumer/lti_1p3/tests/test_deep_linking.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for LTI 1.3 consumer implementation
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.test.testcases import TestCase
+from mock import patch
+
+from lti_consumer.lti_1p3.deep_linking import LtiDeepLinking
+from lti_consumer.lti_1p3 import exceptions
+
+
+class TestLtiDeepLinking(TestCase):
+    """
+    Unit tests for LtiDeepLinking class
+    """
+
+    def setUp(self):
+        """
+        Instance Deep Linking Class for testing.
+        """
+        super().setUp()
+
+        self.dl = LtiDeepLinking(
+            deep_linking_launch_url="launch_url",
+            deep_linking_return_url="return_url"
+        )
+
+    def test_invalid_claim_type(self):
+        """
+        Test DeepLinking claim when invalid type is passed.
+        """
+        with self.assertRaises(exceptions.LtiDeepLinkingContentTypeNotSupported):
+            self.dl.get_lti_deep_linking_launch_claim(
+                accept_types=['invalid_type']
+            )
+
+    def test_claim_type_validation(self):
+        """
+        Test that claims are correctly passed back by the class.
+        """
+        with patch(
+            'lti_consumer.lti_1p3.deep_linking.LTI_DEEP_LINKING_ACCEPTED_TYPES',
+            ['test']
+        ):
+            self.dl.get_lti_deep_linking_launch_claim(
+                accept_types=['test']
+            )
+
+    def test_no_accepted_claim_types(self):
+        """
+        Test DeepLinking when no claim data is passed.
+        """
+        message = self.dl.get_lti_deep_linking_launch_claim(
+            extra_data="deep_linking_hint"
+        )
+
+        self.assertEqual(
+            {
+                'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings': {
+                    'accept_types': [],
+                    'accept_presentation_document_targets': [
+                        'iframe',
+                        'window',
+                        'embed'
+                    ],
+                    'accept_multiple': True,
+                    'auto_create': True,
+                    'title': '',
+                    'text': '',
+                    'deep_link_return_url': 'return_url',
+                    'data': "deep_linking_hint",
+                }
+            },
+            message,
+        )

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -21,6 +21,7 @@ from lti_consumer.plugin import compat
 from lti_consumer.utils import (
     get_lms_base,
     get_lti_ags_lineitems_url,
+    get_lti_deeplinking_response_url,
 )
 
 
@@ -289,6 +290,13 @@ class LtiConfiguration(models.Model):
                 consumer.enable_ags(
                     lineitems_url=get_lti_ags_lineitems_url(self.id),
                     lineitem_url=get_lti_ags_lineitems_url(self.id, lineitem.id),
+                )
+
+            # Check if enabled and setup LTI-DL
+            if self.block.lti_advantage_deep_linking_enabled:
+                consumer.enable_deep_linking(
+                    self.block.lti_advantage_deep_linking_launch_url,
+                    get_lti_deeplinking_response_url(self.id),
                 )
 
             return consumer

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -14,7 +14,9 @@ function LtiConsumerXBlockInitStudio(runtime, element) {
     const lti1P3FieldList = [
         "lti_1p3_launch_url",
         "lti_1p3_oidc_url",
-        "lti_1p3_tool_public_key"
+        "lti_1p3_tool_public_key",
+        "lti_advantage_deep_linking_enabled",
+        "lti_advantage_deep_linking_launch_url"
     ];
 
     /**

--- a/lti_consumer/templates/html/lti_1p3_permission_error.html
+++ b/lti_consumer/templates/html/lti_1p3_permission_error.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>LTI</title>
+    </head>
+    <body>
+        <p>
+            <b>Unauthorized.</b>
+        </p>
+        <p>
+            Students don't have permissions to perform LTI Deep Linking configuration launches.
+        </p>
+    </body>
+</html>

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -40,6 +40,7 @@ class TestLtiConfigurationModel(TestCase):
             # Studio configuration view.
             'lti_1p3_tool_public_key': self.public_key,
             'has_score': True,
+            'lti_advantage_deep_linking_enabled': True,
         }
         self.xblock = make_xblock('lti_consumer', LtiConsumerXBlock, self.xblock_attributes)
         # Set dummy location so that UsageKey lookup is valid
@@ -130,6 +131,18 @@ class TestLtiConfigurationModel(TestCase):
                 }
             }
         )
+
+    def test_lti_consumer_deep_linking_enabled(self):
+        """
+        Check if LTI DL is properly instanced when configured.
+        """
+        self.lti_1p3_config.block = self.xblock
+
+        # Get LTI 1.3 consumer
+        consumer = self.lti_1p3_config.get_lti_consumer()
+
+        # Check that LTI DL class is instanced.
+        self.assertTrue(consumer.dl)
 
     @patch("lti_consumer.models.compat")
     def test_block_property(self, compat_mock):

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -18,6 +18,13 @@ def lti_1p3_enabled():
     return settings.FEATURES.get('LTI_1P3_ENABLED', False) is True  # pragma: no cover
 
 
+def lti_deeplinking_enabled():
+    """
+    Returns `true` if LTI Advantage deep linking is enabled for instance.
+    """
+    return settings.FEATURES.get('LTI_DEEP_LINKING_ENABLED', False) is True  # pragma: no cover
+
+
 def get_lms_base():
     """
     Returns LMS base url to be used as issuer on OAuth2 flows
@@ -83,3 +90,20 @@ def get_lti_ags_lineitems_url(lti_config_id, lineitem_id=None):
         url += "/" + str(lineitem_id)
 
     return url
+
+
+def get_lti_deeplinking_response_url(lti_config_id):
+    """
+    Return the LTI Deep Linking response endpoint
+
+    This is just a dummy URL for now, until we implement the deep
+    linking response endpoint.
+
+    # TODO: Implement Deep Linking Response endpoint
+
+    :param lti_config_id: LTI configuration id
+    """
+    return "{lms_base}/api/lti_consumer/v1/lti/{lti_config_id}/lti-dl/response".format(
+        lms_base=get_lms_base(),
+        lti_config_id=str(lti_config_id),
+    )

--- a/test_settings.py
+++ b/test_settings.py
@@ -16,4 +16,5 @@ LMS_ROOT_URL = "https://example.com"
 # Dummy FEATURES dict
 FEATURES = {
     'LTI_1P3_ENABLED': False,
+    'LTI_DEEPLINKING_ENABLED': False,
 }


### PR DESCRIPTION
This PR partially implements the LTI Advantage Deep Linking Launch flow.
The LTI consumer and LTI Launch sequence is modified to handle messages that contain deep link requests and launch the tool using the proper endpoint and parameters.

**Split from https://github.com/edx/xblock-lti-consumer/pull/112.**

**Testing instructions:**
1. Check out this branch.
2. Set up a test LTI tool that supports Deep Linking (such as IMS's reference tool, https://github.com/IMSGlobal/lti-1-3-php-example-tool or https://github.com/dmitry-viskov/pylti1.3-django-example).
3. Enable LTI_1P3_ENABLED and LTI_DEEP_LINKING_ENABLED on studio.yml FEATURES dict.
4. Check that the normal LTI launch works.
5. Set the LTI Deep link launch url (from IMS's tool is https://lti-ri.imsglobal.org/lti/tools/TOOL_ID/deep_link_launches)
6. Since there's no way of doing deep linking launches yet, apply a small patch to test the deep link launch:
```
diff --git a/lti_consumer/lti_xblock.py b/lti_consumer/lti_xblock.py
index df0cf16..3e5cadd 100644
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1378,7 +1378,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             # Retrieve and set LTI 1.3 Launch start URL
             lti_block_launch_handler = get_lti_1p3_launch_start_url(
                 block=self,
-                deep_link_launch=False,
+                deep_link_launch=True,
                 hint=str(self.location)  # pylint: disable=no-member
             )
```
7. Perform the LTI Deep Link Launch (just do a normal LTI launc), it should work and land on a `Valid` page (if you're using IMS's tool) or in a 404 page in the LMS (if you're using a tool that does the entire deep linking flow).

Reviewers:
- [ ] @shimulch
- [ ] @nedbat

