### PR TITLE
[BD-24] [BB-3374] LTI Deep Linking Content Presentation Endpoint

### DIFF
--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -96,10 +96,28 @@ def publish_grade(block, user, score, possible, only_if_higher=False, score_dele
     )
 
 
-def user_has_staff_access(user, course_key):
+def user_has_access(*args, **kwargs):
     """
-    Check if an user has write permissions to a given course.
+    Import and run `has_access` from LMS
     """
     # pylint: disable=import-error,import-outside-toplevel
     from lms.djangoapps.courseware.access import has_access
-    return has_access(user, "staff", course_key)
+    return has_access(*args, **kwargs)
+
+
+def get_course_by_id(course_key):
+    """
+    Import and run `get_course_by_id` from LMS
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from lms.djangoapps.courseware.courses import get_course_by_id as lms_get_course_by_id
+    return lms_get_course_by_id(course_key)
+
+
+def user_course_access(*args, **kwargs):
+    """
+    Import and run `check_course_access` from LMS
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from lms.djangoapps.courseware.courses import check_course_access
+    return check_course_access(*args, **kwargs)

--- a/lti_consumer/plugin/urls.py
+++ b/lti_consumer/plugin/urls.py
@@ -15,6 +15,7 @@ from lti_consumer.plugin.views import (
     # LTI Advantage URLs
     LtiAgsLineItemViewset,
     deep_linking_response_endpoint,
+    deep_linking_content_endpoint,
 )
 
 
@@ -44,6 +45,11 @@ urlpatterns = [
         r'lti_consumer/v1/lti/(?P<lti_config_id>[-\w]+)/lti-dl/response',
         deep_linking_response_endpoint,
         name='lti_consumer.deep_linking_response_endpoint'
+    ),
+    url(
+        r'lti_consumer/v1/lti/(?P<lti_config_id>[-\w]+)/lti-dl/content',
+        deep_linking_content_endpoint,
+        name='lti_consumer.deep_linking_content_endpoint'
     ),
     url(
         r'lti_consumer/v1/lti/(?P<lti_config_id>[-\w]+)/',

--- a/lti_consumer/templates/html/lti-dl/render_dl_content.html
+++ b/lti_consumer/templates/html/lti-dl/render_dl_content.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>{{ block.display_name }} | Deep Linking Contents</title>
+    </head>
+    <body>
+    </body>
+</html>


### PR DESCRIPTION
This PR adds an endpoint for presenting/rendering Deep Linking Content. This PR depends on #127 

There are a couple of related PR's that should be reviewed and merged in the following order -

1. This PR
2. https://github.com/edx/xblock-lti-consumer/pull/131 - Implements ``link`` content type
3. https://github.com/edx/xblock-lti-consumer/pull/132 - Implements ``html`` content type
4. https://github.com/edx/xblock-lti-consumer/pull/133 - Implements ``image`` content type

**JIRA tickets**: 
https://tasks.opencraft.com/browse/BB-3374

~~**Discussions**:~~

**Dependencies**: None

~~**Screenshots**:~~

~~**Sandbox URL**:~~

**Merge deadline**: None 

**Testing instructions**:

1. Checkout this branch.
2. Set up a local LTI tool (recommended: https://github.com/dmitry-viskov/pylti1.3-django-example) and ngrok tunnel.
3. Change the following in ``lti_consumer/lti_xblock.py`` to allow Deep Link launches:
```
             # Retrieve and set LTI 1.3 Launch start URL
             lti_block_launch_handler = get_lti_1p3_launch_start_url(
                 block=self,
-                deep_link_launch=False,
+                deep_link_launch=True,
                 hint=str(self.location)  # pylint: disable=no-member
             )
```
4. Do a LTI launch (from the LMS).
5. Select an option in the LTI tool's UI.
6. Visit - ``/api/lti_consumer/v1/lti/<LTI_CONFIG_ID>/lti-dl/content``. It should return a ``200`` response.

**Author notes and concerns**:

1. This PR only contains the implementation of the Content Presentation endpoint. The actual rendering of different content types will be on separate PRs.

**Reviewers**
- [ ] @farhaanbukhsh
- [ ] edX reviewer[s] TBD
