### PR TITLE
Skip migration when no LTI XBlock location exists

### DIFF
--- a/lti_consumer/migrations/0005_migrate_keyset_to_model.py
+++ b/lti_consumer/migrations/0005_migrate_keyset_to_model.py
@@ -23,6 +23,8 @@ def forwards_func(apps, schema_editor):
     )
     with transaction.atomic():
         for lti_config in lti_configs:
+            if not lti_config.location:
+                continue
             block = _load_block(lti_config.location)
 
             # If client_id exists, move it to model


### PR DESCRIPTION
otherwise this blows up, trying to migrate a record with no location
(the modulestore lookup throws).

Presumably this isn't (wasn't?) an issue in prod already, right?
But I did hit this in my devstack, having previously created an
LtiConfiguration record via Django Admin (without a location).