### PR TITLE
[BD-24] [BB-3374] LTI Deep Linking Content Presentation - html

### DIFF
--- a/lti_consumer/lti_1p3/constants.py
+++ b/lti_consumer/lti_1p3/constants.py
@@ -54,8 +54,8 @@ LTI_1P3_ACCESS_TOKEN_SCOPES = [
 
 LTI_DEEP_LINKING_ACCEPTED_TYPES = [
     'ltiResourceLink',
+    'link',
     # TODO: implement "image" support,
-    # TODO: implement "link" support,
     # TODO: implement "file" support,
     # TODO: implement "html" support,
 ]

--- a/lti_consumer/lti_1p3/constants.py
+++ b/lti_consumer/lti_1p3/constants.py
@@ -55,9 +55,9 @@ LTI_1P3_ACCESS_TOKEN_SCOPES = [
 LTI_DEEP_LINKING_ACCEPTED_TYPES = [
     'ltiResourceLink',
     'link',
+    'html',
     # TODO: implement "image" support,
     # TODO: implement "file" support,
-    # TODO: implement "html" support,
 ]
 
 

--- a/lti_consumer/lti_1p3/extensions/rest_framework/constants.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/constants.py
@@ -4,10 +4,12 @@ LTI 1.3/Advantage DRF Related Constants
 from .serializers import (
     LtiDlLtiResourceLinkSerializer,
     LtiDlLinkSerializer,
+    LtiDlHtmlSerializer,
 )
 
 
 LTI_DL_CONTENT_TYPE_SERIALIZER_MAP = {
     "ltiResourceLink": LtiDlLtiResourceLinkSerializer,
     "link": LtiDlLinkSerializer,
+    "html": LtiDlHtmlSerializer,
 }

--- a/lti_consumer/lti_1p3/extensions/rest_framework/constants.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/constants.py
@@ -1,9 +1,13 @@
 """
 LTI 1.3/Advantage DRF Related Constants
 """
-from .serializers import LtiDlLtiResourceLinkSerializer
+from .serializers import (
+    LtiDlLtiResourceLinkSerializer,
+    LtiDlLinkSerializer,
+)
 
 
 LTI_DL_CONTENT_TYPE_SERIALIZER_MAP = {
     "ltiResourceLink": LtiDlLtiResourceLinkSerializer,
+    "link": LtiDlLinkSerializer,
 }

--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -271,3 +271,62 @@ class LtiDlLtiResourceLinkSerializer(serializers.Serializer):
     lineItem = LtiDlLineItemSerializer(required=False)
     available = LtiDlTimeDeltaSerializer(required=False)
     submission = LtiDlTimeDeltaSerializer(required=False)
+
+
+# pylint: disable=abstract-method
+class LtiDLIconPropertySerializer(serializers.Serializer):
+    """
+    LTI Deep Linking - `icon` or `thumbnail` property serializer.
+    """
+    url = serializers.URLField(max_length=500)
+    width = serializers.IntegerField(min_value=1)
+    height = serializers.IntegerField(min_value=1)
+
+
+# pylint: disable=abstract-method
+class LtiDlEmbedPropertySerializer(serializers.Serializer):
+    """
+    LTI Deep Linking - `embed` property serializer.
+    """
+    html = serializers.CharField()
+
+
+# pylint: disable=abstract-method
+class LtiDlWindowPropertySerializer(serializers.Serializer):
+    """
+    LTI Deep Linking - `window` property serializer.
+    """
+    targetName = serializers.CharField(max_length=255, required=False)
+    width = serializers.IntegerField(min_value=1, required=False)
+    height = serializers.IntegerField(min_value=1, required=False)
+    windowFeatures = serializers.CharField(required=False)
+
+
+# pylint: disable=abstract-method
+class LtiDlIframePropertySerializer(serializers.Serializer):
+    """
+    LTI Deep Linking - `iframe` property serializer.
+    """
+    src = serializers.URLField(max_length=500)
+    width = serializers.IntegerField(min_value=1)
+    height = serializers.IntegerField(min_value=1)
+
+
+# pylint: disable=abstract-method
+class LtiDlLinkSerializer(serializers.Serializer):
+    """
+    LTI Deep Linking - Link Serializer.
+
+    This serializer implements validation for the Link content type.
+
+    Reference:
+    http://www.imsglobal.org/spec/lti-dl/v2p0#link
+    """
+    url = serializers.URLField(max_length=500)
+    title = serializers.CharField(max_length=255, required=False)
+    text = serializers.CharField(required=False)
+    icon = LtiDLIconPropertySerializer(required=False)
+    thumbnail = LtiDLIconPropertySerializer(required=False)
+    embed = LtiDlEmbedPropertySerializer(required=False)
+    window = LtiDlWindowPropertySerializer(required=False)
+    iframe = LtiDlIframePropertySerializer(required=False)

--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -330,3 +330,18 @@ class LtiDlLinkSerializer(serializers.Serializer):
     embed = LtiDlEmbedPropertySerializer(required=False)
     window = LtiDlWindowPropertySerializer(required=False)
     iframe = LtiDlIframePropertySerializer(required=False)
+
+
+# pylint: disable=abstract-method
+class LtiDlHtmlSerializer(serializers.Serializer):
+    """
+    LTI Deep Linking - html Serializer.
+
+    This serializer implements validation for the HTML Fragment content type.
+
+    Reference:
+    http://www.imsglobal.org/spec/lti-dl/v2p0#html-fragment
+    """
+    html = serializers.CharField()
+    title = serializers.CharField(max_length=255, required=False)
+    text = serializers.CharField(required=False)

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -664,7 +664,7 @@ class TestLtiAdvantageConsumer(TestCase):
             "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiDeepLinkingResponse",
             "https://purl.imsglobal.org/spec/lti-dl/claim/content_items": [
                 {
-                    "type": "link",
+                    "type": "wrongContentType",
                     "url": "https://something.example.com/page.html",
                 },
             ]

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -96,10 +96,28 @@ def publish_grade(block, user, score, possible, only_if_higher=False, score_dele
     )
 
 
-def user_has_staff_access(user, course_key):
+def user_has_access(*args, **kwargs):
     """
-    Check if an user has write permissions to a given course.
+    Import and run `has_access` from LMS
     """
     # pylint: disable=import-error,import-outside-toplevel
     from lms.djangoapps.courseware.access import has_access
-    return has_access(user, "staff", course_key)
+    return has_access(*args, **kwargs)
+
+
+def get_course_by_id(course_key):
+    """
+    Import and run `get_course_by_id` from LMS
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from lms.djangoapps.courseware.courses import get_course_by_id as lms_get_course_by_id
+    return lms_get_course_by_id(course_key)
+
+
+def user_course_access(*args, **kwargs):
+    """
+    Import and run `check_course_access` from LMS
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from lms.djangoapps.courseware.courses import check_course_access
+    return check_course_access(*args, **kwargs)

--- a/lti_consumer/plugin/urls.py
+++ b/lti_consumer/plugin/urls.py
@@ -15,6 +15,7 @@ from lti_consumer.plugin.views import (
     # LTI Advantage URLs
     LtiAgsLineItemViewset,
     deep_linking_response_endpoint,
+    deep_linking_content_endpoint,
 )
 
 
@@ -44,6 +45,11 @@ urlpatterns = [
         r'lti_consumer/v1/lti/(?P<lti_config_id>[-\w]+)/lti-dl/response',
         deep_linking_response_endpoint,
         name='lti_consumer.deep_linking_response_endpoint'
+    ),
+    url(
+        r'lti_consumer/v1/lti/(?P<lti_config_id>[-\w]+)/lti-dl/content',
+        deep_linking_content_endpoint,
+        name='lti_consumer.deep_linking_content_endpoint'
     ),
     url(
         r'lti_consumer/v1/lti/(?P<lti_config_id>[-\w]+)/',

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -194,10 +194,11 @@ def deep_linking_response_endpoint(request, lti_config_id=None):
             LtiDlContentItem.objects.filter(lti_configuration=lti_config).delete()
 
             for content_item in content_items:
+
+                content_type = content_item.get('type')
+
                 # Retrieve serializer (or throw error)
-                serializer_cls = LTI_DL_CONTENT_TYPE_SERIALIZER_MAP[
-                    content_item.get('type')
-                ]
+                serializer_cls = LTI_DL_CONTENT_TYPE_SERIALIZER_MAP[content_type]
 
                 # Validate content item data
                 serializer = serializer_cls(data=content_item)
@@ -206,7 +207,7 @@ def deep_linking_response_endpoint(request, lti_config_id=None):
                 # Save content item
                 LtiDlContentItem.objects.create(
                     lti_configuration=lti_config,
-                    content_type=LtiDlContentItem.LTI_RESOURCE_LINK,
+                    content_type=content_type,
                     attributes=serializer.validated_data,
                 )
 

--- a/lti_consumer/templates/html/lti-dl/render_dl_content.html
+++ b/lti_consumer/templates/html/lti-dl/render_dl_content.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>{{ block.display_name }} | Deep Linking Contents</title>
+    </head>
+    <body>
+    </body>
+</html>

--- a/lti_consumer/templates/html/lti-dl/render_dl_content.html
+++ b/lti_consumer/templates/html/lti-dl/render_dl_content.html
@@ -8,6 +8,8 @@
         {% for item in content_items %}
             {% if item.content_type == 'link' %}
                 {% include "html/lti-dl/render_link.html" with item=item attrs=item.attributes %}
+            {% elif item.content_type == 'html' %}
+                {% include "html/lti-dl/render_html.html" with item=item attrs=item.attributes %}
             {% endif %}
         {% endfor %}
     </body>

--- a/lti_consumer/templates/html/lti-dl/render_dl_content.html
+++ b/lti_consumer/templates/html/lti-dl/render_dl_content.html
@@ -5,5 +5,10 @@
         <title>{{ block.display_name }} | Deep Linking Contents</title>
     </head>
     <body>
+        {% for item in content_items %}
+            {% if item.content_type == 'link' %}
+                {% include "html/lti-dl/render_link.html" with item=item attrs=item.attributes %}
+            {% endif %}
+        {% endfor %}
     </body>
 </html>

--- a/lti_consumer/templates/html/lti-dl/render_html.html
+++ b/lti_consumer/templates/html/lti-dl/render_html.html
@@ -1,0 +1,6 @@
+{% load lti_sanitize %}
+
+{% if attrs.title %}<h2>{{ attrs.title }}</h2>{% endif %}
+{% if attrs.text %}<p>{{ attrs.text }}</p>{% endif %}
+
+{{ attrs.html|lti_sanitize }}

--- a/lti_consumer/templates/html/lti-dl/render_link.html
+++ b/lti_consumer/templates/html/lti-dl/render_link.html
@@ -1,0 +1,18 @@
+{% if attrs.title %}<h2>{{ attrs.title }}</h2>{% endif %}
+{% if attrs.text %}<p>{{ attrs.text }}</p>{% endif %}
+<a
+    {% if attrs.window %}
+    onclick="window.open('{{ attrs.url }}', '{{ attrs.window.targetName|default_if_none:''}}', '{{ attrs.window.windowFeatures|default_if_none:'' }}')"
+    href="#"
+    {% else %}
+    href="{{ attrs.url }}"
+    {% endif %}
+    >
+    {% if attrs.icon %}
+        <img src="{{ attrs.icon.url }}" width="{{ attrs.icon.width }}" height="{{ attrs.icon.height }}" />
+    {% endif %}
+    {% if attrs.thumbnail %}
+        <img src="{{ attrs.thumbnail.url }}" width="{{ attrs.thumbnail.width }}" height="{{ attrs.thumbnail.height }}" />
+    {% endif %}
+    {{ attrs.url }}
+</a>

--- a/lti_consumer/templatetags/lti_sanitize.py
+++ b/lti_consumer/templatetags/lti_sanitize.py
@@ -1,0 +1,19 @@
+"""
+Template tags and helper functions for sanitizing html.
+"""
+import bleach
+
+from django import template
+from django.utils.safestring import mark_safe
+register = template.Library()
+
+
+@register.filter()
+def lti_sanitize(html):
+    """
+    Sanitize a html fragment with bleach.
+    """
+    allowed_tags = bleach.sanitizer.ALLOWED_TAGS + ['img']
+    allowed_attributes = dict(bleach.sanitizer.ALLOWED_ATTRIBUTES, **{'img': ['src', 'alt']})
+    sanitized_html = bleach.clean(html, tags=allowed_tags, attributes=allowed_attributes)
+    return mark_safe(sanitized_html)


### PR DESCRIPTION
Depends on https://github.com/edx/xblock-lti-consumer/pull/131

This PR implements the ``html`` content type for LTI Deep Linking content presentation. Spec - http://www.imsglobal.org/spec/lti-dl/v2p0#html-fragment

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3374

**Discussions**: N/A

**Dependencies**: None

**Screenshots**:
![Screenshot from 2020-12-29 22-45-17](https://user-images.githubusercontent.com/1010244/103299922-df920200-4a27-11eb-9a59-d44687490602.png)


**Sandbox URL**: N/A

**Merge deadline**: None

**Testing instructions**:
1. Assuming you have already tested https://github.com/edx/xblock-lti-consumer/pull/128 in your local devstack, because this PR depends on that.
2. Go to ``http://localhost:18000/admin/lti_consumer/ltidlcontentitem``
3. Create a new item, select the LTI configuration, from content type select ``HTML Fragment``. Put following in the attributes -
```
{"html":"<i>This is a HTML fragment</i><script type='text/javascript'>alert('this should not work')</script>","title":"HTML Fragment","text":"Sample description"}
```
4. Visit - /api/lti_consumer/v1/lti/<LTI_CONFIG_ID>/lti-dl/content. It should render the HTML and sanitize the ``script`` tag.

**Author notes and concerns**:
1. I've used ``bleach`` for sanitizing HTML. But as it is a allow list based sanitizer, we might need to allow a lot of tags here. Currently, it only allows the defaults and image tags.

**Reviewers**
- [ ] @farhaanbukhsh
- [ ] edX reviewer[s] TBD
