### PR TITLE
Fix migration `config_id` conflict.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,6 +298,11 @@ Please do not report security issues in public. Send security concerns via email
 Changelog
 =========
 
+2.5.2 - 2021-01-20
+------------------
+
+* Fix issue with migration that causes migration failure due to duplicate `config_id` values.
+
 2.5.1 - 2021-01-19
 ------------------
 

--- a/lti_consumer/migrations/0006_add_on_model_config_for_lti_1p1.py
+++ b/lti_consumer/migrations/0006_add_on_model_config_for_lti_1p1.py
@@ -6,6 +6,13 @@ import jsonfield.fields
 import uuid
 
 
+def create_config_ids(apps, schema_editor):
+    LtiConfiguration = apps.get_model('lti_consumer', 'LtiConfiguration')
+    for config in LtiConfiguration.objects.all():
+        config.config_id = uuid.uuid4()
+        config.save()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -14,6 +21,12 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
+            model_name='lticonfiguration',
+            name='config_id',
+            field=models.UUIDField(default=uuid.uuid4, null=True),
+        ),
+        migrations.RunPython(create_config_ids),
+        migrations.AlterField(
             model_name='lticonfiguration',
             name='config_id',
             field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='2.5.1',
+    version='2.5.2',
     description='This XBlock implements the consumer side of the LTI specification.',
     long_description=long_description,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
[This](https://github.com/edx/xblock-lti-consumer/pull/130) previous PR added new fields to the `LtiConfiguration` model. One of the newly-added fields was a unique field with a default value. This case needs some [special handling](https://docs.djangoproject.com/en/2.2/howto/writing-migrations/#migrations-that-add-unique-fields) for migrations that the previous PR did not include. This PR adds proper handling for this so that migrations don't result in an error. 

**Merge deadline**: ASAP

**Testing instructions**:

1. If the migration from the previous PR was already applied, remove it by running `python manage.py lms migrate lti_consumer 0005`
2. Install lti-consumer-xblock==2.4.0 
3. Create an LtiConsumer object, it won't have a config_id value.
4. Run any pending migrations. 
5. Install lti-consumer-xblock==2.5.1  (which includes the faulty migration)
6. Re- run migrations. They will fail.
7. Install lti-consumer-xblock from this PR.
8. Re-run migrations, they will succeed.

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD