### PR TITLE
[BD-24][TNL-7824][BB-3373]: Implement ltiResourceLink deep linking content presentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,6 +298,12 @@ Please do not report security issues in public. Send security concerns via email
 Changelog
 =========
 
+2.7.0 - 2021-02-16
+------------------
+
+* Add support for presenting `ltiResourceLink` content from deep linking.
+
+
 2.6.0 - 2021-02-16
 ------------------
 

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -613,3 +613,17 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
 
         # Return contentitems
         return content_items
+
+    def set_dl_content_launch_parameters(
+        self,
+        url=None,
+        custom=None,
+    ):
+        """
+        Overrides LTI Consumer settings to do content presentation.
+        """
+        if url:
+            self.launch_url = url
+
+        if custom:
+            self.set_custom_parameters(custom)

--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -238,8 +238,18 @@ class LtiDlTimeDeltaSerializer(serializers.Serializer):
     containing `startDateTime` and `endDateTime` to signal
     if content if available or gra
     """
-    startDateTime = serializers.DateTimeField(input_formats=[ISO_8601], format=ISO_8601, default_timezone=timezone.utc)
-    endDateTime = serializers.DateTimeField(input_formats=[ISO_8601], format=ISO_8601, default_timezone=timezone.utc)
+    startDateTime = serializers.DateTimeField(
+        input_formats=[ISO_8601],
+        format=ISO_8601,
+        default_timezone=timezone.utc,
+        required=False,
+    )
+    endDateTime = serializers.DateTimeField(
+        input_formats=[ISO_8601],
+        format=ISO_8601,
+        default_timezone=timezone.utc,
+        required=False,
+    )
 
 
 # pylint: disable=abstract-method

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -706,3 +706,23 @@ class TestLtiAdvantageConsumer(TestCase):
         )
 
         self.assertEqual(content_items, [])
+
+    def test_set_dl_content_launch_parameters(self):
+        """
+        Check that the DL overrides replace LTI launch parameters
+        """
+        self._setup_deep_linking()
+
+        # Set DL variables and return LTI message
+        self.lti_consumer.set_dl_content_launch_parameters(
+            url="example.com",
+            custom={"test": "test"},
+        )
+        message = self.lti_consumer.get_lti_launch_message("test_link")
+
+        # Check if custom item was set
+        self.assertEqual(
+            message['https://purl.imsglobal.org/spec/lti/claim/custom'],
+            {"test": "test"}
+        )
+        self.assertEqual(self.lti_consumer.launch_url, "example.com")

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='2.6.0',
+    version='2.7.0',
     description='This XBlock implements the consumer side of the LTI specification.',
     long_description=long_description,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
This PR implements the base LTI Deep Linking content presentation for `ltiResourceLink` types.
68d9c510cba3b78490c48ce8fc83c9a4b0ba5481: contains the full code changes.
5973a4350416ff61bef4e2321685cfe38986b10f: adds tests to check functionality.

**Testing instructions:**
1. Checkout this branch.
2. Set up a local LTI tool (recommended: https://github.com/dmitry-viskov/pylti1.3-django-example) and ngrok tunnel.
3. Do a deep link launch (from Studio link).
5. Select an option in the LTI tool's UI.
6. Go to http://localhost:18000/admin/lti_consumer/ltidlcontentitem/ and check that the option you selected is stored in the model.
7. Go to the LMS and load the LTI section.
8. Check that the local tool opens with the configuration you've selected in step 5.

**Conformance testing:**
1. Set up LTI + Deep linking.
2. Do a LTI launch using the Studio links and post it back to the LMS.
3. Open the LTI section in the LMS, the content from the IMS tool should load.
4. Take a screenshot and upload to their conformance tool.

**Reviewers:**
- [x] @shimulch 
- [ ] @nedbat  