### PR TITLE
fix: Migrate the UUID backfill again

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,6 +298,12 @@ Please do not report security issues in public. Send security concerns via email
 Changelog
 =========
 
+2.5.4 - 2021-02-XX
+------------------
+
+* Fix bug with `config_id` migration where an entry was created _during_
+  the migration and did _not_ receive a valid UUID value.
+
 2.5.3 - 2021-01-26
 ------------------
 

--- a/lti_consumer/migrations/0008_fix_uuid_backfill.py
+++ b/lti_consumer/migrations/0008_fix_uuid_backfill.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+import uuid
+
+
+def create_config_ids(apps, schema_editor):
+    LtiConfiguration = apps.get_model('lti_consumer', 'LtiConfiguration')
+    broken = LtiConfiguration.objects.filter(config_id__isnull=True)
+    for config in broken:
+        config.config_id = uuid.uuid4()
+        config.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lti_consumer', '0007_ltidlcontentitem'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='lticonfiguration',
+            name='config_id',
+            field=models.UUIDField(default=uuid.uuid4, editable=True, unique=True),
+        ),
+        migrations.RunPython(create_config_ids),
+        migrations.AlterField(
+            model_name='lticonfiguration',
+            name='config_id',
+            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        ),
+    ]


### PR DESCRIPTION
To correct the, in our case, single database entry that snuck in without
a UUID during the schema change.

Steps:
- Make the field editable
- Add `config_id` to all models missing it
- Make the field noneditable again