### PR TITLE
[TNL-7520] - Handle case when modal height and width and set to empty in LTI component in studio.

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1427,6 +1427,8 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         Returns:
             float: The css position offset to apply to the modal window
         """
+        if not viewport_percentage:
+            viewport_percentage = 80        # set to default value in case viewport_percentage is None
         return (100 - viewport_percentage) / 2
 
     def get_outcome_service_url(self, service_name="grade_handler"):


### PR DESCRIPTION
### [TNL-7520](https://openedx.atlassian.net/browse/TNL-7520)

### Description

**Expect**: When an instructor enters invalid data, they can re-edit the component to enter valid data.
**Observe**: Instructor enters invalid data to the LTI, and the error message prevents any further editing. The only option is to delete the existing draft. 

#### Reproduction:
1. In Studio as an instructor - create an LTI component.
2. Click Edit. Set either Modal Height or Modal Width to blank. Save.
3. View Error message: " WE'RE HAVING TROUBLE RENDERING YOUR COMPONENT
Students will not be able to access this component. Re-edit your component to fix the error"
Error: unsupported operand type(s) for -: 'int' and 'NoneType'

**Expect**: Option to edit the broken component exists. 
**Observe**: No edit option.

**Side note**: This also prompted feedback on the new microfrontend experience: It is AWESOME how the new learner experience handles this broken component if the instructor was foolish enough to publish it. In the old LMS, the entire subsection throws an error message if you publish the bad LTI component. In the new learning.edx.org, just the relevant unit is broken (fails to load). This is a huge improvement in that it localizes instructor user errors and preserves the rest of the content!
