### PR TITLE
fix: Manually backfill lti_config dicts

### DIFF
--- a/lti_consumer/migrations/0010_backfill-empty-string-lti-config.py
+++ b/lti_consumer/migrations/0010_backfill-empty-string-lti-config.py
@@ -1,0 +1,68 @@
+"""
+Backfill empty lti_config records
+
+We need to do this with raw SQL,
+otherwise the model fails upon instantiation,
+as the empty string is an invalid JSON dictionary.
+"""
+import uuid
+
+from django.db import connection
+from django.db import migrations
+
+
+sql_forward = """\
+UPDATE
+    lti_consumer_lticonfiguration
+SET
+    lti_config = %s
+WHERE
+    id = %s
+;\
+"""
+
+sql_select_empty = """\
+SELECT
+    id
+FROM
+    lti_consumer_lticonfiguration
+WHERE
+    lti_config = ""
+;\
+"""
+
+
+def _get_ids_with_empty_lti_config():
+    """
+    Retrieve the list of primary keys for each entry with a blank lti_config
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(sql_select_empty)
+        for row in cursor.fetchall():
+            yield row[0]
+
+
+def _forward(apps, schema_editor):
+    """
+    Generate an empty JSON dict for rows missing one
+    """
+    for _id in _get_ids_with_empty_lti_config():
+        lti_config = '{}'
+        schema_editor.execute(sql_forward, [
+            lti_config,
+            _id,
+        ])
+
+
+class Migration(migrations.Migration):
+    """
+    Backfill empty lti_config records
+    """
+
+    dependencies = [
+        ('lti_consumer', '0009_backfill-empty-string-config-id'),
+    ]
+
+    operations = [
+        migrations.RunPython(_forward, atomic=False),
+    ]

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='2.7.0',
+    version='2.7.1',
     description='This XBlock implements the consumer side of the LTI specification.',
     long_description=long_description,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
The difficulty here is that the empty string in an invalid JSON
dictionary (as opposed to None/NULL or '{}' which is just "blank");
attempts to instantiate models would fail, given the invalid data. This
meant we couldn't use the Django ORM to handle the migration entirely;
we need to craft some raw SQL to work-around these checks and
limitations.

Related-To: 42a9e342ef57a9ffa5016f4f57da633a811d2c0f
Related-To: https://github.com/edx/xblock-lti-consumer/pull/144