### PR TITLE
[SE-4235] Add missing parameter processors code

### DIFF
--- a/lti_consumer/lti_1p1/consumer.py
+++ b/lti_consumer/lti_1p1/consumer.py
@@ -146,6 +146,9 @@ class LtiConsumer1p1:
         self.lti_launch_presentation_locale = None
         self.lti_custom_parameters = None
 
+        # Extra claims - used for custom parameter processors
+        self.extra_claims = {}
+
     def set_user_data(
             self,
             user_id,
@@ -241,6 +244,14 @@ class LtiConsumer1p1:
 
         self.lti_custom_parameters = custom_parameters
 
+    def set_extra_claims(self, claim):
+        """
+        Updates launch extra claims using python's dict .update method
+        """
+        if not isinstance(claim, dict):
+            raise ValueError('Invalid extra claim: {!r} is not a dict.'.format(claim))
+        self.extra_claims.update(claim)
+
     def generate_launch_request(self, resource_link_id):
         """
         Signs LTI launch request and returns signature and OAuth parameters.
@@ -287,6 +298,10 @@ class LtiConsumer1p1:
         # Appending custom parameter for signing.
         if self.lti_custom_parameters:
             lti_parameters.update(self.lti_custom_parameters)
+
+        # Extra claims - from custom parameter processors
+        if self.extra_claims:
+            lti_parameters.update(self.extra_claims)
 
         headers = {
             # This is needed for body encoding:

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='3.0.2',
+    version='3.0.3',
     author='Open edX project',
     author_email='oscm@edx.org',
     description='This XBlock implements the consumer side of the LTI specification.',


### PR DESCRIPTION
Somewhere between versions 2.0.0 and 2.1.0, the code to handle external parameter processors was dropped. This PR adds it back. Without this, external processors that are specified in the [parameter processors settings](https://github.com/edx/xblock-lti-consumer#configuring-the-parameter-processors-settings) is not called.

**Jira Tickets:**  [OSPR-5686](https://openedx.atlassian.net/browse/OSPR-5686)

**Sandbox URL:** TBD

**Testing Instructions:**

1. Install this branch on your xblock runtime environment (for example xblock-sdk).
2. Test the parameter processors from tahoe-lti as per the [test instructions provided](https://github.com/appsembler/tahoe-lti#development-guide)
3. Verify that the external parameter processors are being called correctly.

**Reviewers**
- [ ] @gabor-boros 
- [ ] edX reviewer TBD