### PR TITLE
fix: Try importing LMS helper from new path

### DIFF
--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -108,9 +108,17 @@ def user_has_access(*args, **kwargs):
 def get_course_by_id(course_key):
     """
     Import and run `get_course_by_id` from LMS
+
+    TODO: Once the LMS has fully switched over to this new path [1],
+    we can remove the legacy (LMS) import support here.
+
+    - [1] https://github.com/edx/edx-platform/pull/27289
     """
     # pylint: disable=import-error,import-outside-toplevel
-    from lms.djangoapps.courseware.courses import get_course_by_id as lms_get_course_by_id
+    try:
+        from openedx.core.lib.courses import get_course_by_id as lms_get_course_by_id
+    except ImportError:
+        from lms.djangoapps.courseware.courses import get_course_by_id as lms_get_course_by_id
     return lms_get_course_by_id(course_key)
 
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='2.7.2',
+    version='2.7.3',
     description='This XBlock implements the consumer side of the LTI specification.',
     long_description=long_description,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
Fall-back to the old path.

Once the LMS has fully switched over to this new path [1],
we can remove the legacy (LMS) import support here.

- [1] https://github.com/edx/edx-platform/pull/27289