### PR TITLE
[BD-24] Minor fixes found while testing documentation

### DIFF
--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -112,7 +112,8 @@ def get_lti_1p3_launch_info(config_id=None, block=None):
         'oidc_callback': get_lms_lti_launch_link(),
         'token_url': get_lms_lti_access_token_link(lti_config.location),
         'deep_linking_launch_url': deep_linking_launch_url,
-        'deep_linking_content_items': json.dumps(deep_linking_content_items, indent=4),
+        'deep_linking_content_items':
+            json.dumps(deep_linking_content_items, indent=4) if deep_linking_content_items else None,
     }
 
 

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -251,9 +251,7 @@ class LtiConsumer1p3:
             "iss": self.iss,
 
             # JWT aud and azp
-            "aud": [
-                self.client_id
-            ],
+            "aud": self.client_id,
             "azp": self.client_id,
 
             # LTI Deployment ID Claim:

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -622,6 +622,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                 'lti_1p3_launch_url',
                 'lti_1p3_oidc_url',
                 'lti_1p3_tool_public_key',
+                'lti_advantage_ags_mode',
                 'lti_advantage_deep_linking_enabled',
                 'lti_advantage_deep_linking_launch_url',
             ]


### PR DESCRIPTION
This PR fixes two small issues found when going through the updated documentation steps:

- e3fe63a: Minor compatibility fix, some tools assume `aud` is a plain text string instead of a list. 
- b288707: Fix deep linking studio view introduced by https://github.com/edx/xblock-lti-consumer/pull/149 and the interaction of `[]` with [the django template](https://github.com/edx/xblock-lti-consumer/blob/master/lti_consumer/templates/html/lti_1p3_studio.html#L370).
- 1b402ee: Add the missing `lti_advantage_ags_mode` to the `hide_fields` setting.

**Testing instructions for 1b402ee:**
1. Checkout `master` branch on your devstack and install.
3. Add `lti_consumer` to a course advanced module list.
4. Add an lti consumer into the course and click **Edit**.
6. You'll see the `LTI Assignment and Grades Service` option (it's not supposed to show up until lti 1.3 is enabled).
7. Checkout this branch and check that the issue is solved.

**Testing instructions for b288707:**
1. Checkout `master` branch on your devstack and install.
2. Enable the `LTI_1P3_ENABLED` and `LTI_DEEP_LINKING_ENABLED` flags in `FEATURES` (studio only).
3. Add `lti_consumer` to a course advanced module list.
4. Add an lti consumer into the course.
5. Set version to `lti 1.3` and **deep linking** to `true`.
6. You'll see `Deep Linking is configured on this tool.` on the studio page even though it's not supposed to appear until a deep-linking is done.
7. Checkout this branch and the `Deep Linking is configured on this tool.` will disappear (only the second part will appear - `You can configure this tool's content using LTI Deep Linking.`)

**Certification suite:**
1. Run the certification suite tests for LTI launch and deep linking - both should work.

**Reviewers:**
- [ ] @viadanna 
- [ ] @nedbat 