### PR TITLE
build: save common_constraints.txt locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,13 @@ test:  ## Run the tests
 covreport:  ## Show the coverage results
 	python -m coverage report -m --skip-covered
 
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q -r requirements/pip_tools.txt
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,26 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<2.3
+
+# docutils version 0.17 is causing docs rendering to fail
+# See https://sourceforge.net/p/docutils/bugs/417/
+docutils==0.16
+
+# latest version is causing e2e failures in edx-platform.
+drf-jwt<1.19.1
+
+# Newer versions causing tests failures in multiple repos.
+pyjwt[crypto]==1.7.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,17 +13,5 @@
  
 # TODO: Many pinned dependencies should be unpinned and/or moved to this constraints file.
 
-# mock version 4.0.0 drops support for python 3.5
-mock<4.0.0
-
-# Zip > 1.2.0 drops support for python 3.5
-zipp<1.2.0
-
-# Newer versions not available in python 3.5
-stevedore<=1.32.0
-
 # Same as in edx-platform
 djangorestframework==3.9.4
-
-# jsonfield2 3.1.0 drops support for python 3.5
-jsonfield2<3.1.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,4 +14,4 @@
 # TODO: Many pinned dependencies should be unpinned and/or moved to this constraints file.
 
 # Same as in edx-platform
-djangorestframework==3.9.4
+djangorestframework<4


### PR DESCRIPTION
so that dependabot can access the constraints file and automatically
create security PRs; it fails if the constraints file is specified via
remote URL.