### PR TITLE
feat: Added multi device support on student_view

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -318,6 +318,12 @@ Please do not report security issues in public. Send security concerns via email
 Changelog
 =========
 
+3.0.1 - 2021-07-09
+-------------------
+
+* Added multi device support on student_view for mobile.
+
+
 3.0.0 - 2021-06-16
 -------------------
 

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -937,6 +937,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         fragment.initialize_js('LtiConsumerXBlock')
         return fragment
 
+    @XBlock.supports("multi_device")
     def student_view(self, context):
         """
         XBlock student view of this component.

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('README.rst') as _f:
 
 setup(
     name='lti-consumer-xblock',
-    version='3.0.0',
+    version='3.0.1',
     author='Open edX project',
     author_email='oscm@edx.org',
     description='This XBlock implements the consumer side of the LTI specification.',


### PR DESCRIPTION
Added multi device support on student_view using xblock.supports

Edx mobile team has been working on this [epic](https://openedx.atlassian.net/browse/LEARNER-8350) Open xBlocks in the Browser. To show xblock on mobile browser xblock needs to send student_view_multi_device as true. Therefore I have added its support.

A similar PR for word cloud xblock:
https://github.com/edx/edx-platform/pull/27386/files

Jira Ticket: https://openedx.atlassian.net/browse/LEARNER-8413
Learner-8413
