### PR TITLE
Allow multiple properties for `launch_presentation` claim (LTI 1.3)

### DIFF
--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -146,7 +146,8 @@ class LtiConsumer1p3:
 
     def set_launch_presentation_claim(
             self,
-            document_target="iframe"
+            document_target="iframe",
+            **other_claims
     ):
         """
         Optional: Set launch presentation claims
@@ -161,6 +162,7 @@ class LtiConsumer1p3:
             "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
                 # Can be one of: iframe, frame, window
                 "document_target": document_target,
+                **other_claims,
                 # TODO: Add support for `return_url` handler to allow the tool
                 # to return error messages back to the lms.
                 # See the spec referenced above for more information.


### PR DESCRIPTION
Previously, only `document_target` property could be set for the launch
presentation claim.

Regarding the official documentation [1], other properties can also be set,
which is what this commit allows.

i.e.
```python
lti_consumer.set_launch_presentation_claim(
	document_target='window',
	locale='fr_FR',
	height=100,
	width=200,
)
```

[1] http://www.imsglobal.org/spec/lti/v1p3/#launch-presentation-claim