### PR TITLE
test: suppress noise

### DIFF
--- a/test.py
+++ b/test.py
@@ -4,7 +4,9 @@ Run tests for the LTI Consumer XBlock
 """
 
 import os
+import logging
 import sys
+import warnings
 
 if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_settings')
@@ -27,6 +29,12 @@ if __name__ == '__main__':
         raise
 
     settings.INSTALLED_APPS += ('lti_consumer',)
+
+    # Suppress logging: it just clutters the test output with error logs that are expected.
+    logging.disable(logging.CRITICAL)
+
+    # Suppress a warning from XBlock: "IdGenerator will be required in the future in order to support XBlockAsides"
+    warnings.filterwarnings("ignore", category=FutureWarning, message=r"IdGenerator will be required.*")
 
     arguments = sys.argv[1:]
     options = [argument for argument in arguments if argument.startswith('-')]


### PR DESCRIPTION
The test suite was generating error log messages when tests would cause
error conditions.  This cluttered the output needlessly, because it
looked like test failures, but were actually tests succeeding.  Now all
log messages are suppresed during the test suite.

In addition, the XBlock runtime generates a warning about needing
IdGenerator in the future.  I'm suppressing this warning also.

Now the test suite just outputs 397 nice dots.