### PR TITLE
fix: Long-term fix for cross-origin iFrames

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -318,6 +318,12 @@ Please do not report security issues in public. Send security concerns via email
 Changelog
 =========
 
+3.0.2 - 2021-11-12
+-------------------
+
+* The modal to confirm information transfer on open of lti in new tab/window has been updated
+  because of a change in how browsers handle iframe permissions.
+
 3.0.1 - 2021-07-09
 -------------------
 

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -106,17 +106,58 @@ function LtiConsumerXBlock(runtime, element) {
 
             // If this instance is configured to require username and/or email, ask user if it is okay to send them
             // Do not launch if it is not okay
+
+            function confirmDialog(message) {
+                var def = $.Deferred();
+                $('<div></div>').appendTo('body') // TODO: this will need some cute styling. It looks like trash but it works.
+                  .html('<div><h6>' + message + '</h6></div>')
+                  .dialog({
+                    modal: true,
+                    title: 'Confirm', //TODO: int8lize these
+                    zIndex: 10000,
+                    autoOpen: true,
+                    width: 'auto',
+                    resizable: false,
+                    buttons: {
+                      Yes: function() {
+                        $('body').append('<h1>Confirm Dialog Result: <i>Yes</i></h1>'); //TODO: int8lize these
+                        def.resolve("Yes");
+                        $(this).dialog("close");
+                      },
+                      No: function() {
+                        $('body').append('<h1>Confirm Dialog Result: <i>No</i></h1>'); //TODO: int8lize these
+                        def.resolve("No");
+                        $(this).dialog("close");
+                      }
+                    },
+                    close: function(event, ui) {
+                      $(this).remove();
+                    }
+                  });
+
+                return def.promise();
+              };
+
+
             if(askToSendUsername && askToSendEmail) {
-                launch = confirm(gettext("Click OK to have your username and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+                msg = gettext("Click OK to have your username and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
             } else if (askToSendUsername) {
-                launch = confirm(gettext("Click OK to have your username sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+                msg = gettext("Click OK to have your username sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
             } else if (askToSendEmail) {
-                launch = confirm(gettext("Click OK to have your e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+                msg = gettext("Click OK to have your e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
             }
 
-            if (launch) {
-                window.open($(this).data('target'));
-            }
+            var destination = $(this).data('target')
+
+            $.when(confirmDialog(msg)).then(
+                function(status) {
+                    if (status == "Yes") {
+                        console.log(destination);
+                        //do the next step
+                        window.open(destination);
+                    }
+                }
+            );
         });
     });
 }

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -105,6 +105,7 @@ function LtiConsumerXBlock(runtime, element) {
 
             // If this instance is configured to require username and/or email, ask user if it is okay to send them
             // Do not launch if it is not okay
+            var destination = $(this).data('target')
 
             function confirmDialog(message) {
                 var def = $.Deferred();
@@ -118,14 +119,14 @@ function LtiConsumerXBlock(runtime, element) {
                     width: 'auto',
                     resizable: false,
                     buttons: {
-                      Yes: function() {
+                      OK: function() {
                         $('body').append('<h1>Confirm Dialog Result: <i>Yes</i></h1>');
                         def.resolve("OK");
                         $(this).dialog("close");
                       },
-                      No: function() {
+                      Cancel: function() {
                         $('body').append('<h1>Confirm Dialog Result: <i>No</i></h1>');
-                        def.resolve("No");
+                        def.resolve("Cancel");
                         $(this).dialog("close");
                       }
                     },
@@ -137,20 +138,18 @@ function LtiConsumerXBlock(runtime, element) {
                 return def.promise();
               };
 
-
             if(askToSendUsername && askToSendEmail) {
                 msg = gettext("Click OK to have your username and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
             } else if (askToSendUsername) {
                 msg = gettext("Click OK to have your username sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
             } else if (askToSendEmail) {
                 msg = gettext("Click OK to have your e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
+            } else {
+                window.open(destination);
             }
-
-            var destination = $(this).data('target')
-
             $.when(confirmDialog(msg)).then(
                 function(status) {
-                    if (status == "Ok") {
+                    if (status == "OK") {
                         window.open(destination);
                     }
                 }

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -102,7 +102,6 @@ function LtiConsumerXBlock(runtime, element) {
 
         // Apply click handler to new window launch button
         $element.find('.btn-lti-new-window').click(function(){
-            var launch = true;
 
             // If this instance is configured to require username and/or email, ask user if it is okay to send them
             // Do not launch if it is not okay
@@ -113,19 +112,19 @@ function LtiConsumerXBlock(runtime, element) {
                   .html('<div><h6>' + message + '</h6></div>')
                   .dialog({
                     modal: true,
-                    title: 'Confirm', //TODO: int8lize these
+                    title: 'Confirm',
                     zIndex: 10000,
                     autoOpen: true,
                     width: 'auto',
                     resizable: false,
                     buttons: {
                       Yes: function() {
-                        $('body').append('<h1>Confirm Dialog Result: <i>Yes</i></h1>'); //TODO: int8lize these
-                        def.resolve("Yes");
+                        $('body').append('<h1>Confirm Dialog Result: <i>Yes</i></h1>');
+                        def.resolve("OK");
                         $(this).dialog("close");
                       },
                       No: function() {
-                        $('body').append('<h1>Confirm Dialog Result: <i>No</i></h1>'); //TODO: int8lize these
+                        $('body').append('<h1>Confirm Dialog Result: <i>No</i></h1>');
                         def.resolve("No");
                         $(this).dialog("close");
                       }
@@ -151,9 +150,7 @@ function LtiConsumerXBlock(runtime, element) {
 
             $.when(confirmDialog(msg)).then(
                 function(status) {
-                    if (status == "Yes") {
-                        console.log(destination);
-                        //do the next step
+                    if (status == "Ok") {
                         window.open(destination);
                     }
                 }


### PR DESCRIPTION
For [TNL-8584](https://openedx.atlassian.net/wiki/spaces/PT/pages/3221028876/TNL-8584+Discovery+Long-term+fix+for+cross-origin+iFrames) I need to make a proof of concept of a "Open resource in new window" modal dialog. 

Context: Our current LTI Component XBlock provides an option to "View resource in a New Window", which uses JS to launch a new window/tab. These capabilities were removed in Chrome v92. Here's some referances to those changes: TL;DR: there is a temporary cookie workaround, but this problem also started occurring on Safari 15. 

https://developer.chrome.com/origintrials/#/view_trial/2541156089743802369

. Chrome provided a temporary work-around which we now use in production. But we now need to design and implement a longer term fix.

These issues have since migrated to Safari, and “before other browsers implement this change, which they have indicated that they will” we need to resolve this issue with something other than band-aids. Google Chrome’s and Safari’s move, however, is aligned with making iFrame technology more secure, which we can read as a signal that the industry will continue to advance in the direction of iFrames.

This is that. It obviously needs some styling fixes, as well as internationalization & a11y work, but it works as expected.

screenshot:
<img width="686" alt="Screen Shot 2021-11-04 at 11 30 12 AM" src="https://user-images.githubusercontent.com/49422820/140359942-f4543b65-f2f0-4c70-bcd1-759621ba44df.png">
 