### PR TITLE
docs: reflect changes in changelog and version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -318,11 +318,16 @@ Please do not report security issues in public. Send security concerns via email
 Changelog
 =========
 
-3.0.2 - 2021-11-12
+3.1.1 - 2021-11-12
 -------------------
 
 * The modal to confirm information transfer on open of lti in new tab/window has been updated
   because of a change in how browsers handle iframe permissions.
+
+3.1.0 - 2021-10-?
+-------------------
+
+* The changes which led to this version change were not adequetly documented.
 
 3.0.1 - 2021-07-09
 -------------------

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .lti_xblock import LtiConsumerXBlock
 from .apps import LTIConsumerApp
 
-__version__ = '3.1.0'
+__version__ = '3.1.1'


### PR DESCRIPTION
Upon inspecting [#207](https://github.com/edx/xblock-lti-consumer/commit/133d3e9b7e5a9647c48aa8dd82886cfa1b437f31#:~:text=Merge%20pull%20request-,%23204,-from%20edx/fix) The change-logs did not reflect the move from 3.0.0 to 3.1.0. These changes makes that cklear that that information is missing, while also bumping up the version to reflect LTI changes.