### PR TITLE
fix: add  Learner to LTI launch roles in addition to existing Student role

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -369,6 +369,10 @@ Changelog
 
 Please See the [releases tab](https://github.com/edx/xblock-lti-consumer/releases) for the complete changelog.
 
+4.0.1 - 2022-05-09
+------------------
+* Add `Learner` to LTI launch roles in addition to the `Student` value
+
 4.0.0 - 2022-05-09
 ------------------
 

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -96,7 +96,7 @@ DOCS_ANCHOR_TAG_OPEN = (
 )
 RESULT_SERVICE_SUFFIX_PARSER = re.compile(r"^user/(?P<anon_id>\w+)", re.UNICODE)
 ROLE_MAP = {
-    'student': 'Student',
+    'student': 'Student,Learner',
     'staff': 'Administrator',
     'instructor': 'Instructor',
 }
@@ -716,7 +716,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         Get system user role and convert it to LTI role.
         """
         role = self.runtime.service(self, 'user').get_current_user().opt_attrs.get('edx-platform.user_role', 'student')
-        return ROLE_MAP.get(role, 'Student')
+        return ROLE_MAP.get(role, 'Student,Learner')
 
     @property
     def course(self):

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -137,13 +137,13 @@ class TestProperties(TestLtiConsumerXBlock):
             'edx-platform.user_role': 'student'
         }
         self.xblock.runtime.service(self, 'user').get_current_user = Mock(return_value=fake_user)
-        self.assertEqual(self.xblock.role, 'Student')
+        self.assertEqual(self.xblock.role, 'Student,Learner')
 
         fake_user.opt_attrs = {
             'edx-platform.user_role': 'guest'
         }
         self.xblock.runtime.service(self, 'user').get_current_user = Mock(return_value=fake_user)
-        self.assertEqual(self.xblock.role, 'Student')
+        self.assertEqual(self.xblock.role, 'Student,Learner')
 
         fake_user.opt_attrs = {
             'edx-platform.user_role': 'staff'


### PR DESCRIPTION
### Description
[MST-1503](https://2u-internal.atlassian.net/browse/MST-1503)
Add Learner role to the existing Student role
This is to fix the LTI integration edX has with Frost