### PR TITLE
feat: add platform name to 1.1 and 1.3 claims

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+921.0 - 2023-05-02
+------------------
+* Add platform name as an LTI parameter to LTI 1.1 launches as the "tool_consumer_info_product_family_code" parameter.
+* Add platform name as an LTI parameter to LTI 1.3 launches as the "platform instance" claim.
+
 9.1.0 - 2023-04-28
 ------------------
 * Add full name as an LTI parameter to LTI 1.1 launches as the "lis_person_name_full" parameter.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.1.0'
+__version__ = '9.2.0'

--- a/lti_consumer/lti_1p1/consumer.py
+++ b/lti_consumer/lti_1p1/consumer.py
@@ -9,6 +9,8 @@ import json
 import logging
 import urllib.parse
 
+from django.conf import settings
+
 from .exceptions import Lti1p1Error
 from .oauth import get_oauth_request_signature, verify_oauth_body_signature
 
@@ -280,6 +282,8 @@ class LtiConsumer1p1:
 
             # Parameters required for grading:
             'resource_link_id': resource_link_id,
+
+            'tool_consumer_info_product_family_code': settings.PLATFORM_NAME,
         }
 
         # Check if user data is set, then append it to lti message

--- a/lti_consumer/lti_1p1/tests/test_consumer.py
+++ b/lti_consumer/lti_1p1/tests/test_consumer.py
@@ -3,8 +3,9 @@ Unit tests for lti_consumer.lti_1p1.consumer module
 """
 
 import unittest
-
 from unittest.mock import Mock, patch
+
+from django.conf import settings
 
 from lti_consumer.lti_1p1.exceptions import Lti1p1Error
 from lti_consumer.lti_1p1.consumer import LtiConsumer1p1, parse_result_json
@@ -177,6 +178,7 @@ class TestLtiConsumer1p1(unittest.TestCase):
             'oauth_signature_method': 'fake_method',
             'oauth_consumer_key': 'fake_consumer_key',
             'oauth_signature': 'fake_signature',
+            'tool_consumer_info_product_family_code': settings.PLATFORM_NAME,
         }
         self.assertEqual(lti_parameters, expected_lti_parameters)
 
@@ -246,6 +248,7 @@ class TestLtiConsumer1p1(unittest.TestCase):
             'oauth_signature_method': 'fake_method',
             'oauth_consumer_key': 'fake_consumer_key',
             'oauth_signature': 'fake_signature',
+            'tool_consumer_info_product_family_code': settings.PLATFORM_NAME,
         }
         self.assertEqual(lti_parameters, expected_lti_parameters)
 

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -3,6 +3,9 @@ LTI 1.3 Consumer implementation
 """
 import logging
 from urllib.parse import urlencode
+import uuid
+
+from django.conf import settings
 
 from lti_consumer.lti_1p3.exceptions import InvalidClaimValue
 from lti_consumer.utils import cache_lti_1p3_launch_data, check_token_claim, get_data_from_cache
@@ -348,6 +351,16 @@ class LtiConsumer1p3:
             # Context claim
             if self.lti_claim_context:
                 lti_message.update(self.lti_claim_context)
+
+            # Platform instance claim
+            # The GUID must be consistent across platform deployments, so we have opted to generate a UUID
+            # based on a namespace identifier and the platform name itself.
+            guid = uuid.uuid5(uuid.NAMESPACE_DNS, settings.PLATFORM_NAME)
+            platform_instance_claim = {'guid': str(guid), 'name': settings.PLATFORM_NAME}
+            platform_instance_claim = {
+                "https://purl.imsglobal.org/spec/lti/claim/tool_platform": platform_instance_claim
+            }
+            lti_message.update(platform_instance_claim)
 
             # Custom variables claim
             if self.lti_claim_custom_parameters:

--- a/test_settings.py
+++ b/test_settings.py
@@ -25,3 +25,6 @@ REST_FRAMEWORK = {
 DEFAULT_HASHING_ALGORITHM = "sha1"
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+# Platform name for LTI 1.1 and 1.3 claims testing
+PLATFORM_NAME = "Your platform name here"


### PR DESCRIPTION
## [MST-1880](https://2u-internal.atlassian.net/browse/MST-1880)

Some LTI tools require a platform name in order for the LTI integration to be successful. The name is sent using the `tool_consumer_info_product_family_code` parameter for LTI 1.1, and the platform instance claim for LTI 1.3.