### PR TITLE
fix: Convert UUIDField columns to uuid type for MariaDB

### DIFF
--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.14.2'
+__version__ = '9.14.3'

--- a/lti_consumer/migrations/0019_mariadb_uuid_conversion.py
+++ b/lti_consumer/migrations/0019_mariadb_uuid_conversion.py
@@ -1,0 +1,74 @@
+# Generated migration for MariaDB UUID field conversion (Django 5.2)
+"""
+Migration to convert UUIDField from char(32) to uuid type for MariaDB compatibility.
+
+This migration is necessary because Django 5 changed the behavior of UUIDField for MariaDB
+databases from using CharField(32) to using a proper UUID type. This change isn't managed
+automatically, so we need to generate migrations to safely convert the columns.
+
+This migration only executes for MariaDB databases and is a no-op for other backends.
+
+See: https://www.albertyw.com/note/django-5-mariadb-uuidfield
+"""
+
+from django.db import migrations
+
+
+def apply_mariadb_migration(apps, schema_editor):
+    """Apply the migration only for MariaDB databases."""
+    connection = schema_editor.connection
+
+    # Check if this is a MariaDB database
+    if connection.vendor != 'mysql':
+        return
+
+    # Additional check for MariaDB specifically (vs MySQL)
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+
+    # Apply the field changes for MariaDB
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "ALTER TABLE lti_consumer_lticonfiguration "
+            "MODIFY config_id uuid NOT NULL"
+        )
+
+
+def reverse_mariadb_migration(apps, schema_editor):
+    """Reverse the migration only for MariaDB databases."""
+    connection = schema_editor.connection
+
+    # Check if this is a MariaDB database
+    if connection.vendor != 'mysql':
+        return
+
+    # Additional check for MariaDB specifically (vs MySQL)
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT VERSION()")
+        version = cursor.fetchone()[0]
+        if 'mariadb' not in version.lower():
+            return
+
+    # Reverse the field changes for MariaDB
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "ALTER TABLE lti_consumer_lticonfiguration "
+            "MODIFY config_id char(32) NOT NULL"
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lti_consumer', '0018_increase_length_of_resource_id'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=apply_mariadb_migration,
+            reverse_code=reverse_mariadb_migration,
+        ),
+    ]


### PR DESCRIPTION
## Description
The behavior of the MariaDB backend has changed for UUIDField from a `CharField(32)` to an actual `uuid` type in Django 5. This migration converts affected columns to prevent data insertion errors.

This migration converts the following column:
- `lti_consumer_lticonfiguration.config_id`

## Supporting information
https://docs.djangoproject.com/en/5.2/releases/5.0/#migrating-uuidfield

## Related PRs
- https://github.com/openedx/edx-platform/pull/37494
- https://github.com/openedx/enterprise-catalog/pull/1108
- https://github.com/openedx/edx-enterprise/pull/2472
- https://github.com/openedx/django-user-tasks/pull/446
- https://github.com/openedx/edx-submissions/pull/321
- https://github.com/openedx/edx-ora2/pull/2338