### PR TITLE
feat: sync config with modulestore to fix copy-paste

### DIFF
--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -4,27 +4,34 @@ Python APIs used to handle LTI configuration and launches.
 Some methods are meant to be used inside the XBlock, so they
 return plaintext to allow easy testing/mocking.
 """
-
 import json
+from uuid import UUID
 
+from django.conf import settings
 from opaque_keys.edx.keys import CourseKey
 
 from lti_consumer.lti_1p3.constants import LTI_1P3_ROLE_MAP
+from lti_consumer.lti_xblock import LtiConsumerXBlock
+
+from .filters import get_external_config_from_filter
 from .models import CourseAllowPIISharingInLTIFlag, LtiConfiguration, LtiDlContentItem
 from .utils import (
     get_cache_key,
     get_data_from_cache,
-    get_lti_1p3_context_types_claim,
-    get_lti_deeplinking_content_url,
+    get_lms_lti_access_token_link,
     get_lms_lti_keyset_link,
     get_lms_lti_launch_link,
-    get_lms_lti_access_token_link,
+    get_lti_1p3_context_types_claim,
+    get_lti_deeplinking_content_url,
 )
-from .filters import get_external_config_from_filter
 
 
-def _get_or_create_local_lti_config(lti_version, block_location,
-                                    config_store=LtiConfiguration.CONFIG_ON_XBLOCK, external_id=None):
+def _get_or_create_local_lti_config(
+    lti_version: str,
+    block_location: str,
+    config_store=LtiConfiguration.CONFIG_ON_XBLOCK,
+    external_id: str | None = None,
+) -> LtiConfiguration:
     """
     Retrieve the LtiConfiguration for the block described by block_location, if one exists. If one does not exist,
     create an LtiConfiguration with the LtiConfiguration.CONFIG_ON_XBLOCK config_store.
@@ -48,14 +55,14 @@ def _get_or_create_local_lti_config(lti_version, block_location,
     return lti_config
 
 
-def _get_config_by_config_id(config_id):
+def _get_config_by_config_id(config_id: UUID):
     """
     Gets the LTI config by its UUID config ID
     """
     return LtiConfiguration.objects.get(config_id=config_id)
 
 
-def _get_lti_config_for_block(block):
+def _get_lti_config_for_block(block: LtiConsumerXBlock) -> LtiConfiguration:
     """
     Retrieves or creates a LTI Configuration for a block.
 
@@ -88,12 +95,27 @@ def _get_lti_config_for_block(block):
     return lti_config
 
 
+def _sync_block_data_from_db(block: LtiConsumerXBlock, config: LtiConfiguration) -> None:
+    """
+    Synchronizes data from the database to the block in the modulestore.
+    """
+    block.lti_1p3_client_id = config.lti_1p3_client_id
+    block.lti_1p3_internal_private_key = config.lti_1p3_internal_private_key
+    block.lti_1p3_internal_private_key_id = config.lti_1p3_internal_private_key_id
+    block.lti_1p3_internal_public_jwk = config.lti_1p3_internal_public_jwk
+    block.save()
+    # FIXME: Confirm if this is the correct way to save the block
+    block.runtime.modulestore.update_item(block, None)
+
+
 def config_id_for_block(block):
     """
     Returns the externally facing config_id of the LTI Configuration used by this block,
     creating one if required. That ID is suitable for use in launch data or get_consumer.
     """
     config = _get_lti_config_for_block(block)
+    if settings.SERVICE_VARIANT == 'cms':
+        _sync_block_data_from_db(block, config)
     return config.config_id
 
 

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -42,14 +42,16 @@ def _get_or_create_local_lti_config(
     This allows XBlock users to update the LTI version without needing to update the database.
     """
     # The create operation is only performed when there is no existing configuration for the block
+    defaults = {
+        "lti_1p3_internal_private_key": block.lti_1p3_internal_private_key,
+        "lti_1p3_internal_private_key_id": block.lti_1p3_internal_private_key_id,
+        "lti_1p3_internal_public_jwk": block.lti_1p3_internal_public_jwk,
+    }
+    if block.lti_1p3_client_id:
+        defaults["lti_1p3_client_id"] = block.lti_1p3_client_id
     lti_config, _ = LtiConfiguration.objects.get_or_create(
         location=block.scope_ids.usage_id,
-        defaults={
-            "lti_1p3_client_id": block.lti_1p3_client_id,
-            "lti_1p3_internal_private_key": block.lti_1p3_internal_private_key,
-            "lti_1p3_internal_private_key_id": block.lti_1p3_internal_private_key_id,
-            "lti_1p3_internal_public_jwk": block.lti_1p3_internal_public_jwk,
-        }
+        defaults=defaults
     )
 
     lti_config.config_store = config_store
@@ -113,7 +115,8 @@ def _sync_block_data_from_db(block: LtiConsumerXBlock, config: LtiConfiguration)
     block.lti_1p3_internal_public_jwk = config.lti_1p3_internal_public_jwk
     block.save()
     # FIXME: Confirm if this is the correct way to save the block
-    block.runtime.modulestore.update_item(block, None)
+    if hasattr(block.runtime, 'modulestore'):
+        block.runtime.modulestore.update_item(block, None)
 
 
 def config_id_for_block(block):

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -28,7 +28,7 @@ from .utils import (
 
 def _get_or_create_local_lti_config(
     lti_version: str,
-    block_location: str,
+    block: LtiConsumerXBlock,
     config_store=LtiConfiguration.CONFIG_ON_XBLOCK,
     external_id: str | None = None,
 ) -> LtiConfiguration:
@@ -42,7 +42,15 @@ def _get_or_create_local_lti_config(
     This allows XBlock users to update the LTI version without needing to update the database.
     """
     # The create operation is only performed when there is no existing configuration for the block
-    lti_config, _ = LtiConfiguration.objects.get_or_create(location=block_location)
+    lti_config, _ = LtiConfiguration.objects.get_or_create(
+        location=block.scope_ids.usage_id,
+        defaults={
+            "lti_1p3_client_id": block.lti_1p3_client_id,
+            "lti_1p3_internal_private_key": block.lti_1p3_internal_private_key,
+            "lti_1p3_internal_private_key_id": block.lti_1p3_internal_private_key_id,
+            "lti_1p3_internal_public_jwk": block.lti_1p3_internal_public_jwk,
+        }
+    )
 
     lti_config.config_store = config_store
     lti_config.external_id = external_id
@@ -72,7 +80,7 @@ def _get_lti_config_for_block(block: LtiConsumerXBlock) -> LtiConfiguration:
     if block.config_type == 'database':
         lti_config = _get_or_create_local_lti_config(
             block.lti_version,
-            block.scope_ids.usage_id,
+            block,
             LtiConfiguration.CONFIG_ON_DB,
         )
     elif block.config_type == 'external':
@@ -82,14 +90,14 @@ def _get_lti_config_for_block(block: LtiConsumerXBlock) -> LtiConfiguration:
         )
         lti_config = _get_or_create_local_lti_config(
             config.get("version"),
-            block.scope_ids.usage_id,
+            block,
             LtiConfiguration.CONFIG_EXTERNAL,
             external_id=block.external_config,
         )
     else:
         lti_config = _get_or_create_local_lti_config(
             block.lti_version,
-            block.scope_ids.usage_id,
+            block,
             LtiConfiguration.CONFIG_ON_XBLOCK,
         )
     return lti_config

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -60,11 +60,11 @@ import bleach
 from django.conf import settings
 from django.utils import timezone
 from web_fragments.fragment import Fragment
-
 from webob import Response
 from xblock.core import List, Scope, String, XBlock
 from xblock.fields import Boolean, Float, Integer
 from xblock.validation import ValidationMessage
+
 try:
     from xblock.utils.resources import ResourceLoader
     from xblock.utils.studio_editable import StudioEditableXBlockMixin
@@ -340,6 +340,30 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             "uri's the tool may request."
         ),
         scope=Scope.settings
+    )
+    lti_1p3_client_id = String(
+        display_name=_("Client ID"),
+        default='',
+        scope=Scope.settings,
+        help=_("Client ID used by LTI tool"),
+    )
+    lti_1p3_internal_private_key = String(
+        display_name=_("Internal Private Key"),
+        default='',
+        scope=Scope.settings,
+        help=_("Platform's generated Private key. Keep this value secret."),
+    )
+    lti_1p3_internal_private_key_id = String(
+        display_name=_("Internal Private Key ID"),
+        default='',
+        scope=Scope.settings,
+        help=_("Platform's generated Private key ID"),
+    )
+    lti_1p3_internal_public_jwk = String(
+        display_name=_("Internal Public JWK"),
+        default='',
+        scope=Scope.settings,
+        help=_("Platform's generated JWK keyset."),
     )
 
     lti_1p3_tool_key_mode = String(


### PR DESCRIPTION
- **refactor: store 1.3 fields in modulestore and sync with db**
- **refactor: set default values from block while creating lti config db row**
