### PR TITLE
fix: quote resource_link_id properly as it is used in url by tools

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1669,7 +1669,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             user_role=self.role,
             config_id=config_id,
             # resource_link_id is used in the url params by the tool, so it should be url encoded.
-            resource_link_id=str(urllib.parse.quote(str(location))),
+            resource_link_id=urllib.parse.quote(str(location)),
             external_user_id=self.external_user_id,
             preferred_username=username,
             name=full_name,

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1896,7 +1896,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
             "user_id": 1,
             "user_role": "instructor",
             "config_id": config_id_for_block(self.xblock),
-            "resource_link_id": str(urllib.parse.quote(str(self.xblock.scope_ids.usage_id))),
+            "resource_link_id": urllib.parse.quote(str(self.xblock.scope_ids.usage_id)),
             "external_user_id": "external_user_id",
             "launch_presentation_document_target": "iframe",
             "message_type": "LtiResourceLinkRequest",


### PR DESCRIPTION
The resource-link-id is used by the tool in a GET request (included in the query params) like so:

```
GET "https://ulmo.openedx.io/api/lti_consumer/v1/lti/3/lti-ags?resource_link_id=block-v1:edx+LTI101+2026+type@lti_consumer+block@ff4f12d57abc480eb2a3ec89eacb165a"
```

The `+` symbols are removed when the platform receives this request and the resource_link_id cannot be parsed with below error:

```
opaque_keys.InvalidKeyError: <class 'opaque_keys.edx.locator.CourseLocator'>: UNIX UNX1 2026_T1 type@lti_consumer block@a07db98b8d074e4b977ea4cbfbbd20a8
```

This PR quotes the resource_link_id properly to avoid this issue.

Issue: https://github.com/openedx/xblock-lti-consumer/issues/605
`Private-ref`: https://tasks.opencraft.com/browse/FAL-4327

**Test instructions:**

* Follow steps described in https://openedx.atlassian.net/wiki/spaces/COMM/pages/5542707201/Guide+H5P+1.3+integration+Needs+update
* Before saving the xblock in step 4, update following settings
  * Deep linking: True
  * Deep linking launch url: Same as launch url
  * LTI Assignment and Grades Service: programmatic (**Note:** This is required to reproduce the bug, but even with this fix the grade pass back still fails. You can set this to `declarative` to make grade pass back work but the tool doesn't send the above GET request in this case)
  * Scored: True
* Go to <studio_url>/admin/lti_consumer/courseallowpiisharinginltiflag/ and enable pii sharing for your course.
* Go back to the xblock settings, you'll notice three new fields:
  * Request users' username
  * Request users' full name
  * Request users' email
  Set all of them to True
* Save the xblock
* Click on deep linking lauch - configure tool
* Select any problem from h5p and insert it.
* Publish the block and test it in LMS.


**The bug only appears if you set the `LTI Assignment and Grades Service` to `programmatic` the first time without saving the block even once.** 

**Reason:** The [LtiAgsLineItem](https://github.com/open-craft/xblock-lti-consumer/blob/99a3bbebdc848e651a47c1b0547a98eb035dfb82/lti_consumer/models.py#L470-L503) is not created when `programmatic` is selected and the tool for some reason calls the above GET request and our platform fails with 500 error.

**Note:** Even after fixing this 500 error the grade pass back fails due to missing `LtiAgsLineItem` when `programmatic` is selected, you need to select `declarative` for it to work.
