### PR TITLE
revert: quoting of resource_link_id to align with LTI spec

### DIFF
--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -1,7 +1,6 @@
 """
 Serializers for LTI-related endpoints
 """
-import urllib.parse
 from datetime import timezone
 
 from opaque_keys import InvalidKeyError
@@ -13,7 +12,7 @@ from lti_consumer.lti_1p3.constants import LTI_1P3_CONTEXT_ROLE_MAP
 from lti_consumer.models import LtiAgsLineItem, LtiAgsScore
 
 
-class EncodedUsageKeyField(serializers.Field):
+class UsageKeyField(serializers.Field):
     """
     This serializer field converts from a form of encoded usage key
     to an instance of UsageKey. This is useful for LTI request parameters,
@@ -31,11 +30,8 @@ class EncodedUsageKeyField(serializers.Field):
         """
         try:
             return UsageKey.from_string(data)
-        except InvalidKeyError:
-            try:
-                return UsageKey.from_string(urllib.parse.unquote(data))
-            except InvalidKeyError as err:
-                raise serializers.ValidationError(f"Invalid usage key: {data!r}") from err
+        except InvalidKeyError as err:
+            raise serializers.ValidationError(f"Invalid usage key: {data!r}") from err
 
 
 class LtiAgsLineItemSerializer(serializers.ModelSerializer):
@@ -66,7 +62,7 @@ class LtiAgsLineItemSerializer(serializers.ModelSerializer):
     # Mapping from snake_case to camelCase
     resourceId = serializers.CharField(source='resource_id', required=False)
     scoreMaximum = serializers.IntegerField(source='score_maximum')
-    resourceLinkId = EncodedUsageKeyField(required=False, source='resource_link_id')
+    resourceLinkId = UsageKeyField(required=False, source='resource_link_id')
     startDateTime = serializers.DateTimeField(required=False, source='start_date_time')
     endDateTime = serializers.DateTimeField(required=False, source='end_date_time')
 
@@ -388,7 +384,7 @@ class LtiContextSerializer(serializers.Serializer):
     """
     Serializer for a LTI Context
     """
-    id = EncodedUsageKeyField()
+    id = UsageKeyField()
 
 
 class LtiNrpsContextMemberBasicSerializer(serializers.Serializer):

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1668,8 +1668,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             user_id=self.lms_user_id,
             user_role=self.role,
             config_id=config_id,
-            # resource_link_id is used in the url params by the tool, so it should be url encoded.
-            resource_link_id=urllib.parse.quote(str(location)),
+            resource_link_id=str(location),
             external_user_id=self.external_user_id,
             preferred_username=username,
             name=full_name,

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -4,7 +4,6 @@ Unit tests for LtiConsumerXBlock
 import json
 import logging
 import string
-import urllib.parse
 from datetime import timedelta
 from itertools import product
 from unittest.mock import Mock, PropertyMock, patch
@@ -1896,7 +1895,7 @@ class TestLtiConsumer1p3XBlock(TestCase):
             "user_id": 1,
             "user_role": "instructor",
             "config_id": config_id_for_block(self.xblock),
-            "resource_link_id": urllib.parse.quote(str(self.xblock.scope_ids.usage_id)),
+            "resource_link_id": str(self.xblock.scope_ids.usage_id),
             "external_user_id": "external_user_id",
             "launch_presentation_document_target": "iframe",
             "message_type": "LtiResourceLinkRequest",


### PR DESCRIPTION
**Description:**

This reverts commit 2b5fc5ced880dc81d920bb85f312ee31ee4ddd4f and parts of f78cce704ae3.

More information can be found in https://github.com/openedx/xblock-lti-consumer/issues/621

**Related issue:** https://github.com/openedx/xblock-lti-consumer/issues/621
