### PR TITLE
build: Fail when we can't load common common_constraints.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ covreport:  ## Show the coverage results
 COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
 .PHONY: $(COMMON_CONSTRAINTS_TXT)
 $(COMMON_CONSTRAINTS_TXT):
-	wget -O "$(@)" https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+	wget -O "$(@)" https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in


### PR DESCRIPTION
If we can't get the common_constraints.txt file from edx-lint it is
safer to fail than to pretend the file is empty as there are global
constraints which we want to make sure don't get missed.

See https://github.com/openedx/xblock-lti-consumer/pull/635 for what can happen without this fix.