### PR TITLE
fix: Multiple bug fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+11.0.1 - 2026-04-23
+--------------------
+* Fix LTI 1.3 deep linking `target_link_uri` handling in both preflight and launch token generation.
+* Fix AGS results endpoint/serializer URL generation for optional `user_id`, including trailing-slash compatibility.
+* Allow AGS score `comment` to be blank and improve related API test coverage.
+* Use `get_lti_consumer()` OAuth credentials for LTI 1.1 signature/logging paths and align LTI 1.1 errors with shared `LtiError`.
+* Minor internal cleanup: public `get_lti_consumer()` rename, launch URL typing/casting, and fallback to block `lti_version` when config version is missing.
+
 11.0.0 - 2026-04-20
 --------------------
 * Split LTI 1.3 Configuration into Passport Model

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '11.0.0'
+__version__ = '11.0.1'

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -107,7 +107,8 @@ def _get_or_create_local_lti_config(lti_version, block, config_store=LtiConfigur
     updates = {
         'config_store': config_store,
         'external_id': block.external_config,
-        'version': lti_version,
+        # fallback on block lti_version if lti_version is None
+        'version': lti_version or block.lti_version,
     }
     if passport:
         updates['lti_1p3_passport'] = passport

--- a/lti_consumer/lti_1p1/exceptions.py
+++ b/lti_consumer/lti_1p1/exceptions.py
@@ -1,9 +1,10 @@
 """
 Exceptions for the LTI1.1 Consumer.
 """
+from lti_consumer.exceptions import LtiError
 
 
-class Lti1p1Error(Exception):
+class Lti1p1Error(LtiError):
     """
     General error class for LTI1.1 Consumer usage.
     """

--- a/lti_consumer/lti_1p3/consumer.py
+++ b/lti_consumer/lti_1p3/consumer.py
@@ -77,6 +77,15 @@ class LtiConsumer1p3:
         # Extra claims - used by LTI Advantage
         self.extra_claims = {}
 
+    def _get_target_link_uri(self, launch_data):  # pylint: disable=unused-argument
+        """
+        Return the target_link_uri to use for the provided launch data.
+
+        Subclasses can override this to customize the target link selection for
+        different message types.
+        """
+        return self.launch_url
+
     @staticmethod
     def _get_user_roles(role):
         """
@@ -125,12 +134,14 @@ class LtiConsumer1p3:
 
         oidc_url = self.oidc_url + "?"
 
+        target_link_uri = self._get_target_link_uri(launch_data)
+
         login_hint = user_id
         parameters = {
             "iss": self.iss,
             "client_id": self.client_id,
             "lti_deployment_id": self.deployment_id,
-            "target_link_uri": self.launch_url,
+            "target_link_uri": target_link_uri,
             "login_hint": login_hint,
             "lti_message_hint": launch_data_key,
         }
@@ -302,6 +313,7 @@ class LtiConsumer1p3:
     def get_lti_launch_message(
             self,
             include_extra_claims=True,
+            target_link_uri=None,
     ):
         """
         Build LTI message from class parameters
@@ -311,6 +323,8 @@ class LtiConsumer1p3:
         """
         # Start from base message
         lti_message = LTI_BASE_MESSAGE.copy()
+
+        target_link_uri = target_link_uri or self.launch_url
 
         # Add base parameters
         lti_message.update({
@@ -329,7 +343,7 @@ class LtiConsumer1p3:
             # Target Link URI: actual endpoint for the LTI resource to display
             # MUST be the same value as the target_link_uri passed by the platform in the OIDC login request
             # http://www.imsglobal.org/spec/lti/v1p3/#target-link-uri
-            "https://purl.imsglobal.org/spec/lti/claim/target_link_uri": self.launch_url,
+            "https://purl.imsglobal.org/spec/lti/claim/target_link_uri": target_link_uri,
         })
 
         # Check if user data is set, then append it to lti message
@@ -609,6 +623,19 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
         else:
             return False
 
+    def _get_target_link_uri(self, launch_data):
+        """
+        Use the deep linking launch URL for deep linking requests.
+        """
+        if (
+            getattr(self, 'dl', None) and
+            launch_data and
+            getattr(launch_data, 'message_type', None) == 'LtiDeepLinkingRequest'
+        ):
+            return self.dl.deep_linking_launch_url
+
+        return super()._get_target_link_uri(launch_data)
+
     def enable_ags(
         self,
         lineitems_url,
@@ -663,12 +690,14 @@ class LtiAdvantageConsumer(LtiConsumer1p3):
 
         # Check if Deep Linking is enabled and that this is a Deep Link Launch
         if self.dl and launch_data.message_type == "LtiDeepLinkingRequest":
+            target_link_uri = self._get_target_link_uri(launch_data)
             # Validate preflight response
             self._validate_preflight_response(preflight_response)
 
             # Get LTI Launch Message
             lti_launch_message = self.get_lti_launch_message(
                 include_extra_claims=False,
+                target_link_uri=target_link_uri,
             )
 
             # Update message type to LtiDeepLinkingRequest,

--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -194,13 +194,15 @@ class LtiAgsResultSerializer(serializers.ModelSerializer):
 
     def get_id(self, obj):
         request = self.context.get('request')
+        kwargs = {
+            'lti_config_id': obj.line_item.lti_configuration.id,
+            'pk': obj.line_item.pk,
+        }
+        if obj.user_id:
+            kwargs['user_id'] = obj.user_id
         return reverse(
             'lti_consumer:lti-ags-view-results',
-            kwargs={
-                'lti_config_id': obj.line_item.lti_configuration.id,
-                'pk': obj.line_item.pk,
-                'user_id': obj.user_id,
-            },
+            kwargs=kwargs,
             request=request,
         )
 

--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -193,6 +193,9 @@ class LtiAgsResultSerializer(serializers.ModelSerializer):
     comment = serializers.CharField()
 
     def get_id(self, obj):
+        """
+        Return result URL for score. Include user_id when score scoped to learner.
+        """
         request = self.context.get('request')
         kwargs = {
             'lti_config_id': obj.line_item.lti_configuration.id,

--- a/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
+++ b/lti_consumer/lti_1p3/extensions/rest_framework/serializers.py
@@ -125,7 +125,7 @@ class LtiAgsScoreSerializer(serializers.ModelSerializer):
     timestamp = serializers.DateTimeField(input_formats=[ISO_8601], format=ISO_8601, default_timezone=timezone.utc)
     scoreGiven = serializers.FloatField(source='score_given', required=False, allow_null=True, default=None)
     scoreMaximum = serializers.FloatField(source='score_maximum', required=False, allow_null=True, default=None)
-    comment = serializers.CharField(required=False, allow_null=True)
+    comment = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     activityProgress = serializers.CharField(source='activity_progress')
     gradingProgress = serializers.CharField(source='grading_progress')
     userId = serializers.CharField(source='user_id')

--- a/lti_consumer/lti_1p3/tests/test_consumer.py
+++ b/lti_consumer/lti_1p3/tests/test_consumer.py
@@ -28,7 +28,8 @@ from lti_consumer.lti_1p3.exceptions import InvalidClaimValue, MissingRequiredCl
 ISS = "http://test-platform.example/"
 OIDC_URL = "http://test-platform/oidc"
 LAUNCH_URL = "http://test-platform/launch"
-REDIRECT_URIS = [LAUNCH_URL]
+DEEP_LINK_LAUNCH_URL = "http://test-platform/deep_link_launch"
+REDIRECT_URIS = [LAUNCH_URL, DEEP_LINK_LAUNCH_URL]
 CLIENT_ID = "1"
 DEPLOYMENT_ID = "1"
 NONCE = "1234"
@@ -739,14 +740,14 @@ class TestLtiAdvantageConsumer(TestCase):
         """
         Set's up deep linking class in LTI consumer.
         """
-        self.lti_consumer.enable_deep_linking("launch-url", "return-url")
+        self.lti_consumer.enable_deep_linking(DEEP_LINK_LAUNCH_URL, "return-url")
 
         lti_message_hint = self._setup_lti_message_hint()
 
         # Set LTI Consumer parameters
         self.preflight_response = {
             "client_id": CLIENT_ID,
-            "redirect_uri": LAUNCH_URL,
+            "redirect_uri": DEEP_LINK_LAUNCH_URL,
             "nonce": NONCE,
             "state": STATE,
             "lti_message_hint": lti_message_hint,
@@ -817,6 +818,40 @@ class TestLtiAdvantageConsumer(TestCase):
         self.assertEqual(
             decoded_token['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings']['deep_link_return_url'],
             "return-url"
+        )
+
+    def test_deep_linking_preflight_uses_deep_link_launch_url(self):
+        """
+        Ensure deep linking launches send the deep linking launch URL as target_link_uri during login initiation.
+        """
+        self.lti_consumer.enable_deep_linking(DEEP_LINK_LAUNCH_URL, "return-url")
+        launch_data = Lti1p3LaunchData(
+            user_id="1",
+            user_role="student",
+            config_id="1",
+            resource_link_id="resource_link_id",
+            message_type="LtiDeepLinkingRequest",
+        )
+
+        preflight_request_data = self.lti_consumer.prepare_preflight_url(launch_data)
+        parameters = parse_qs(urlparse(preflight_request_data).query)
+
+        self.assertEqual(parameters['target_link_uri'][0], DEEP_LINK_LAUNCH_URL)
+
+    def test_deep_linking_launch_request_sets_target_link_uri(self):
+        """
+        Ensure the ID token for deep linking launches uses the deep linking launch URL as target_link_uri.
+        """
+        self._setup_deep_linking()
+
+        token = self.lti_consumer.generate_launch_request(
+            self.preflight_response,
+        )['id_token']
+
+        decoded_token = self.lti_consumer.key_handler.validate_and_decode(token)
+        self.assertEqual(
+            decoded_token['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'],
+            DEEP_LINK_LAUNCH_URL,
         )
 
     def test_deep_linking_token_decode_no_dl(self):

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1600,11 +1600,11 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         self.module_score = scaled_score
         self.score_comment = comment
 
-    def _get_lti_launch_url(self, consumer):
+    def _get_lti_launch_url(self, consumer) -> str:
         """
         Return the LTI launch URL.
         """
-        launch_url = self.launch_url
+        launch_url = str(self.launch_url)
 
         # The lti_launch_url property only exists on the LtiConsumer1p1. The LtiConsumer1p3 does not have an
         # attribute with this name, so ensure that we're accessing it on the appropriate consumer class.

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1109,7 +1109,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             close_date = due_date
         return close_date is not None and timezone.now() > close_date
 
-    def _get_lti_consumer(self):
+    def get_lti_consumer(self):
         """
         Returns a preconfigured LTI consumer depending on the value.
 
@@ -1282,7 +1282,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         Returns:
             webob.response: HTML LTI launch form
         """
-        lti_consumer = self._get_lti_consumer()
+        lti_consumer = self.get_lti_consumer()
 
         # Occassionally, users try to do an LTI launch while they are unauthenticated. It is not known why this occurs.
         # Sometimes, it is due to a web crawlers; other times, it is due to actual users of the platform. Regardless,
@@ -1385,7 +1385,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         # Asserting that the consumer can be created. This makes sure that the LtiConfiguration
         # object exists before calling the Django View
-        assert self._get_lti_consumer()
+        assert self.get_lti_consumer()
         # Runtime import because this can only be run in the LMS/Studio Django
         # environments. Importing the views on the top level will cause RuntimeErorr
         from lti_consumer.plugin.views import access_token_endpoint  # pylint: disable=import-outside-toplevel
@@ -1441,12 +1441,11 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         Returns:
             webob.response:  response to this request.  See above for details.
         """
-        lti_consumer = self._get_lti_consumer()
+        lti_consumer = self.get_lti_consumer()
         lti_consumer.set_outcome_service_url(self.outcome_service_url)
 
         if settings.DEBUG:
-            lti_provider_key, lti_provider_secret = self.lti_provider_key_secret
-            log_authorization_header(request, lti_provider_key, lti_provider_secret)
+            log_authorization_header(request, lti_consumer.oauth_key, lti_consumer.oauth_secret)
 
         if not self.accept_grades_past_due and self.is_past_due:
             return Response(status=404)  # have to do 404 due to spec, but 400 is better, with error msg in body
@@ -1758,7 +1757,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         # Don't pull from the Django database unless the config_type is one that stores the LTI configuration in the
         # database.
         if self.config_type in ("database", "external"):
-            lti_consumer = self._get_lti_consumer()
+            lti_consumer = self.get_lti_consumer()
 
         launch_url = self._get_lti_launch_url(lti_consumer)
         lti_block_launch_handler = self._get_lti_block_launch_handler()

--- a/lti_consumer/outcomes.py
+++ b/lti_consumer/outcomes.py
@@ -6,10 +6,12 @@ https://www.imsglobal.org/specs/ltiomv1p0
 """
 
 import logging
-from xml.sax.saxutils import escape
 from urllib.parse import unquote
+from xml.sax.saxutils import escape
 
+from django.conf import settings
 from lxml import etree
+
 try:
     from xblock.utils.resources import ResourceLoader
 except ModuleNotFoundError:  # For backward compatibility with releases older than Quince.
@@ -176,7 +178,13 @@ class OutcomeService:
             return response_xml_template.format(**failure_values)
 
         # Verify OAuth signing.
-        __, secret = self.xblock.lti_provider_key_secret
+        secret = self.xblock.get_lti_consumer().oauth_secret
+        if settings.DEBUG:
+            log.debug(
+                "[LTI]: verifying OAuth body signature for outcomes. service_url=%s request.url=%s",
+                self.xblock.outcome_service_url,
+                request.url,
+            )
         try:
             verify_oauth_body_signature(request, secret, self.xblock.outcome_service_url)
         except (ValueError, LtiError) as ex:

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -748,7 +748,7 @@ class LtiAgsLineItemViewset(viewsets.ModelViewSet):
     @action(
         detail=True,
         methods=['GET'],
-        url_path='results/(?P<user_id>[^/.]+)?',
+        url_path=r'results(?:/(?P<user_id>[^/.]+))?/?',
         renderer_classes=[LineItemResultsRenderer],
         content_negotiation_class=IgnoreContentNegotiation,
     )

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -177,10 +177,7 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
             response.data,
             [
                 {
-                    'id': 'http://testserver/lti_consumer/v1/lti/{}/lti-ags/{}'.format(
-                        self.lti_config.id,
-                        line_item.id
-                    ),
+                    'id': f'http://testserver/lti_consumer/v1/lti/{self.lti_config.id}/lti-ags/{line_item.id}',
                     'resourceId': 'test',
                     'scoreMaximum': 100,
                     'label': 'test label',
@@ -221,10 +218,7 @@ class LtiAgsViewSetLineItemTests(LtiAgsLineItemViewSetTestCase):
         self.assertEqual(
             response.data,
             {
-                'id': 'http://testserver/lti_consumer/v1/lti/{}/lti-ags/{}'.format(
-                    self.lti_config.id,
-                    line_item.id
-                ),
+                'id': f'http://testserver/lti_consumer/v1/lti/{self.lti_config.id}/lti-ags/{line_item.id}',
                 'resourceId': 'test',
                 'scoreMaximum': 100,
                 'label': 'test label',
@@ -936,11 +930,14 @@ class LtiAgsViewSetResultsTests(LtiAgsLineItemViewSetTestCase):
 
         # Create Score
         response = self.client.get(self.results_endpoint)
+        response_with_trailing_slash = self.client.get(self.results_endpoint + '/')
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_with_trailing_slash.status_code, 200)
 
         # There should be 2 results (not include the empty score user's result)
         self.assertEqual(len(response.data), 2)
+        self.assertEqual(len(response_with_trailing_slash.data), 2)
 
         # Check the data
         primary_user_results_endpoint = reverse(
@@ -983,7 +980,7 @@ class LtiAgsViewSetResultsTests(LtiAgsLineItemViewSetTestCase):
 
     def test_retrieve_results_for_user_id(self):
         """
-        Test the LTI AGS LineItem Resul Retrieval for a single user.
+        Test the LTI AGS LineItem Result Retrieval for a single user.
         """
         self._set_lti_token('https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly')
 
@@ -996,14 +993,23 @@ class LtiAgsViewSetResultsTests(LtiAgsLineItemViewSetTestCase):
             }
         )
 
+        results_user_endpoint_with_trailing_slash = results_user_endpoint + '/'
+
         # Request results with userId
         response = self.client.get(results_user_endpoint, data={"userId": self.secondary_user_id})
+        response_with_trailing_slash = self.client.get(
+            results_user_endpoint_with_trailing_slash,
+            data={"userId": self.secondary_user_id},
+        )
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_with_trailing_slash.status_code, 200)
 
         # There should be 1 result for that user
         self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response_with_trailing_slash.data), 1)
         self.assertEqual(response.data[0]['userId'], self.secondary_user_id)
+        self.assertEqual(response_with_trailing_slash.data[0]['userId'], self.secondary_user_id)
 
     def test_retrieve_results_with_limit(self):
         """
@@ -1023,3 +1029,30 @@ class LtiAgsViewSetResultsTests(LtiAgsLineItemViewSetTestCase):
         # `primary_user_id` was assigned to the record with the `late_timestamp`
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['userId'], self.primary_user_id)
+
+    def test_results_serializer_id_includes_user_id_separator(self):
+        """
+        Test that the results serializer builds a valid URL for a user-specific result.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly')
+
+        results_user_endpoint = reverse(
+            'lti_consumer:lti-ags-view-results',
+            kwargs={
+                "lti_config_id": self.lti_config.id,
+                "pk": self.line_item.id,
+                "user_id": self.secondary_user_id,
+            }
+        )
+
+        response = self.client.get(results_user_endpoint, data={"userId": self.secondary_user_id})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(
+            response.data[0]['id'],
+            (
+                f'http://testserver/lti_consumer/v1/lti/{self.lti_config.id}/lti-ags'
+                f'/{self.line_item.id}/results/{self.secondary_user_id}'
+            ),
+        )

--- a/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_ags.py
@@ -395,6 +395,43 @@ class LtiAgsViewSetScoresTests(LtiAgsLineItemViewSetTestCase):
         self.assertEqual(score.grading_progress, LtiAgsScore.FULLY_GRADED)
         self.assertEqual(score.user_id, self.primary_user_id)
 
+    @ddt.data(None, "")
+    def test_create_score_without_comment(self, comment):
+        """
+        Test the LTI AGS LineItem Score Creation when comment is omitted or blank.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-ags/scope/score')
+
+        data = {
+            "timestamp": self.early_timestamp,
+            "scoreGiven": 83,
+            "scoreMaximum": 100,
+            "activityProgress": LtiAgsScore.COMPLETED,
+            "gradingProgress": LtiAgsScore.FULLY_GRADED,
+            "userId": self.primary_user_id,
+        }
+        if comment is not None:
+            data["comment"] = comment
+
+        response = self.client.post(
+            self.scores_endpoint,
+            data=json.dumps(data),
+            content_type="application/vnd.ims.lis.v1.score+json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(LtiAgsScore.objects.filter(
+            line_item=self.line_item,
+            user_id=self.primary_user_id
+        ).count(), 1)
+
+        score = LtiAgsScore.objects.get(line_item=self.line_item, user_id=self.primary_user_id)
+        if comment is None:
+            self.assertIsNone(score.comment)
+        else:
+            self.assertEqual(score.comment, comment)
+        score.delete()
+
     def _post_lti_score(self, override_data=None):
         """
         Helper method to post a LTI score

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -773,7 +773,7 @@ class TestEditableFields(TestLtiConsumerXBlock):
 
 class TestGetLti1p1Consumer(TestLtiConsumerXBlock):
     """
-    Unit tests for LtiConsumerXBlock._get_lti_consumer()
+    Unit tests for LtiConsumerXBlock.get_lti_consumer()
     """
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
     @patch('lti_consumer.models.LtiConsumer1p1')
@@ -788,7 +788,7 @@ class TestGetLti1p1Consumer(TestLtiConsumerXBlock):
         type(mock_course).lti_passports = PropertyMock(return_value=[f"{provider}:{key}:{secret}"])
 
         with patch('lti_consumer.plugin.compat.load_enough_xblock', return_value=self.xblock):
-            self.xblock._get_lti_consumer()  # pylint: disable=protected-access
+            self.xblock.get_lti_consumer()  # pylint: disable=protected-access
 
         mock_lti_consumer.assert_called_with(self.xblock.launch_url, key, secret)
 
@@ -1020,7 +1020,7 @@ class TestLtiLaunchHandler(TestLtiConsumerXBlock):
                 'roles': 'Student',
             })
         )
-        self.xblock._get_lti_consumer = Mock(return_value=self.mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=self.mock_lti_consumer)  # pylint: disable=protected-access
         self.xblock.due = timezone.now()
         self.xblock.graceperiod = timedelta(days=1)
 
@@ -1187,7 +1187,7 @@ class TestResultServiceHandler(TestLtiConsumerXBlock):
         self.lti_provider_secret = 'secret'
         self.xblock.accept_grades_past_due = True
         self.mock_lti_consumer = Mock()
-        self.xblock._get_lti_consumer = Mock(return_value=self.mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=self.mock_lti_consumer)  # pylint: disable=protected-access
 
         mock_user = Mock()
         mock_id = PropertyMock(return_value=1)
@@ -1196,15 +1196,13 @@ class TestResultServiceHandler(TestLtiConsumerXBlock):
 
     @override_settings(DEBUG=True)
     @patch('lti_consumer.lti_xblock.log_authorization_header')
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer')
-    def test_runtime_debug_true(self, mock_get_lti_consumer, mock_log_auth_header):
+    def test_runtime_debug_true(self, mock_log_auth_header):
         """
         Test `log_authorization_header` is called when settings.DEBUG is True
         """
-        mock_get_lti_consumer.return_value = Mock(
-            oauth_key=self.lti_provider_key,
-            oauth_secret=self.lti_provider_secret,
-        )
+        self.mock_lti_consumer.oauth_key = self.lti_provider_key
+        self.mock_lti_consumer.oauth_secret = self.lti_provider_secret
+
         request = make_request('', 'GET')
         self.xblock.result_service_handler(request)
 
@@ -1675,7 +1673,7 @@ class TestGetContext(TestLtiConsumerXBlock):
         lti_launch_url = 'www.example.org'
         mock_lti_consumer = Mock()
         type(mock_lti_consumer).lti_launch_url = PropertyMock(return_value=lti_launch_url)
-        self.xblock._get_lti_consumer = Mock(return_value=mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=mock_lti_consumer)  # pylint: disable=protected-access
 
         context = self.xblock._get_context_for_template()  # pylint: disable=protected-access
         self.assertEqual(context['launch_url'], lti_launch_url)
@@ -1695,7 +1693,7 @@ class TestGetContext(TestLtiConsumerXBlock):
         lti_1p3_launch_url = 'www.example.org'
         mock_lti_consumer = Mock()
         type(mock_lti_consumer).launch_url = PropertyMock(return_value=lti_1p3_launch_url)
-        self.xblock._get_lti_consumer = Mock(return_value=mock_lti_consumer)  # pylint: disable=protected-access
+        self.xblock.get_lti_consumer = Mock(return_value=mock_lti_consumer)  # pylint: disable=protected-access
 
         # Calling _get_lti_block_launch_handler raises an error because the mocked XBlock location attribute does not
         # act like a UsageKey, so mock out get_lti_1p3_launch_data to avoid accessing it.

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1196,12 +1196,15 @@ class TestResultServiceHandler(TestLtiConsumerXBlock):
 
     @override_settings(DEBUG=True)
     @patch('lti_consumer.lti_xblock.log_authorization_header')
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret')
-    def test_runtime_debug_true(self, mock_lti_provider_key_secret, mock_log_auth_header):
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer')
+    def test_runtime_debug_true(self, mock_get_lti_consumer, mock_log_auth_header):
         """
         Test `log_authorization_header` is called when settings.DEBUG is True
         """
-        mock_lti_provider_key_secret.__get__ = Mock(return_value=(self.lti_provider_key, self.lti_provider_secret))
+        mock_get_lti_consumer.return_value = Mock(
+            oauth_key=self.lti_provider_key,
+            oauth_secret=self.lti_provider_secret,
+        )
         request = make_request('', 'GET')
         self.xblock.result_service_handler(request)
 

--- a/lti_consumer/tests/unit/test_outcomes.py
+++ b/lti_consumer/tests/unit/test_outcomes.py
@@ -348,7 +348,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.mock_get_user_id_patcher_enabled.return_value = mock_user
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_handle_replace_result_success(self):
         """
@@ -407,7 +407,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('Request body XML parsing error', response)
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature')
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_invalid_signature(self, mock_verify):
         """
@@ -422,7 +422,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('failure', self.outcome_service.handle_request(request))
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_user_not_found(self):
         """
@@ -437,7 +437,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('User not found', response)
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'unsupportedRequest')))
     def test_unsupported_action(self):
         """

--- a/lti_consumer/tests/unit/test_outcomes.py
+++ b/lti_consumer/tests/unit/test_outcomes.py
@@ -348,7 +348,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.mock_get_user_id_patcher_enabled.return_value = mock_user
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_handle_replace_result_success(self):
         """
@@ -407,7 +407,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('Request body XML parsing error', response)
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature')
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_invalid_signature(self, mock_verify):
         """
@@ -422,7 +422,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('failure', self.outcome_service.handle_request(request))
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'replaceResultRequest')))
     def test_user_not_found(self):
         """
@@ -437,7 +437,7 @@ class TestOutcomeService(TestLtiConsumerXBlock):
         self.assertIn('User not found', response)
 
     @patch('lti_consumer.outcomes.verify_oauth_body_signature', Mock(return_value=True))
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.lti_provider_key_secret', PropertyMock(return_value=('t', 's')))
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock._get_lti_consumer', Mock(return_value=Mock(oauth_secret='s')))
     @patch('lti_consumer.outcomes.parse_grade_xml_body', Mock(return_value=('', '', 0.5, 'unsupportedRequest')))
     def test_unsupported_action(self):
         """


### PR DESCRIPTION
**Description**:

- Deep linking launch uses correct target_link_uri so tools hit deep link endpoint
- Scores API accepts blank comment per spec expectations
- AGS result endpoint works with or without trailing slash
- Uses correct key-secret pair based on config_store type

**Supporting information:**

Fixes following issues:

* https://github.com/openedx/xblock-lti-consumer/issues/633
* https://github.com/openedx/xblock-lti-consumer/issues/628
* https://github.com/openedx/xblock-lti-consumer/issues/637
* https://github.com/openedx/xblock-lti-consumer/issues/620

`Private-ref`: https://tasks.opencraft.com/browse/FAL-4346

**Test instructions:**

**For #633**

* Create an LTI xblock and link it with saltire.
* Enable deep linking and use a slightly different deep linking url like: https://saltire.lti.app/tool?test=1
* Publish and click on `Deep linking Launch - Configure tool` in studio.
* Verify that the `https://purl.imsglobal.org/spec/lti/claim/target_link_uri` field is set to the deep linking url in `Message Claims (derived from message parameters)` section

For #628 

* Use the same block and open it in LMS.
* Go to `Services` -> `OAuth 2 Access Token`, select all scopes and request a new token.
* Go to `Message` -> `Services Available` -> `Result` section
* Under `Result` section, click on `Read` button. It should not fail.

For #637

* Just below `Result` section, click on `Score publish Service` section
* Fill in all fields but leave `Comment` field empty and click on `Create/Update` button. It should not fail.

For #620 

* Could not test this locally due.
* TODO: test on sandbox.