### PR TITLE
fix: resolve LTI version conflicts for external configs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ----------
 
+11.3.0 - 2026-05-29
+--------------------
+* Sync effective LTI version from external reusable configurations throughout XBlock runtime paths and Studio.
+* Hide LTI version selection in Studio for external and database-backed configurations to avoid stale version mismatches.
+* Show or hide LTI launch URL fields in Studio based on version resolved from external configuration.
+
 11.2.0 - 2026-04-30
 --------------------
 * Replace the flat Studio editor with a multi-step wizard (Setup → Advantage Settings → Review Options).

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '11.2.0'
+__version__ = '11.3.0'

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -147,12 +147,8 @@ def _get_lti_config_for_block(block):
             {"course_key": block.scope_ids.usage_id.context_key},
             block.external_config
         )
-        # External config may use ``version`` or ``lti_version``
-        # (ADR 0006 uses ``lti_version``).  Normalize the value so
-        # LtiConfiguration.version always stores internal format.
-        raw_version = config.get("version") or config.get("lti_version")
         lti_config = _get_or_create_local_lti_config(
-            LtiConfiguration._normalize_version(raw_version) if raw_version else None,
+            config.get("version"),
             block,
             LtiConfiguration.CONFIG_EXTERNAL,
         )

--- a/lti_consumer/api.py
+++ b/lti_consumer/api.py
@@ -147,8 +147,12 @@ def _get_lti_config_for_block(block):
             {"course_key": block.scope_ids.usage_id.context_key},
             block.external_config
         )
+        # External config may use ``version`` or ``lti_version``
+        # (ADR 0006 uses ``lti_version``).  Normalize the value so
+        # LtiConfiguration.version always stores internal format.
+        raw_version = config.get("version") or config.get("lti_version")
         lti_config = _get_or_create_local_lti_config(
-            config.get("version"),
+            LtiConfiguration._normalize_version(raw_version) if raw_version else None,
             block,
             LtiConfiguration.CONFIG_EXTERNAL,
         )

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1268,6 +1268,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                 self.scope_ids.usage_id.course_key
             ),
             "editableFields": self.editable_fields,
+            "effectiveLtiVersion": self.get_effective_lti_version(),
         }
 
         statici18n_js_url = self._get_statici18n_js_url()

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -74,6 +74,7 @@ except ModuleNotFoundError:  # For backward compatibility with releases older th
 
 from .data import Lti1p3LaunchData
 from .exceptions import LtiError
+from .filters import get_external_config_from_filter
 from .lti_1p1.consumer import LTI_PARAMETERS, LtiConsumer1p1, parse_result_json
 from .lti_1p1.oauth import log_authorization_header
 from .outcomes import OutcomeService
@@ -661,7 +662,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         # a new LTI ID before they've added it to advanced settings, but we do want to warn them about it.
         # If we put this check in validate_field_data(), the settings editor wouldn't let them save changes.
         course = self.course
-        if course and self.get_effective_lti_version() == "lti_1p1" and self.lti_id:
+        if course and self.config_type == "new" and self.lti_version == "lti_1p1" and self.lti_id:
             lti_passport_ids = [lti_passport.split(':')[0].strip() for lti_passport in course.lti_passports]
             if self.lti_id.strip() not in lti_passport_ids:
                 validation.add(ValidationMessage(ValidationMessage.WARNING, str(
@@ -1121,16 +1122,29 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         if self.config_type != "external":
             return self.lti_version
 
-        # Runtime import since this will only run in the
-        # Open edX LMS/Studio environments.
-        # pylint: disable=import-outside-toplevel
-        from lti_consumer.filters import get_external_config_from_filter
-
         config = get_external_config_from_filter(
             {"course_key": self.scope_ids.usage_id.context_key},
             self.external_config,
         )
         return config.get("version") or self.lti_version
+
+    @XBlock.json_handler
+    def resolve_external_config_version(self, data, suffix=''):
+        """
+        Handler for Studio to resolve the LTI version for a given
+        external config ID.  Returns only the version — no secrets
+        from the external configuration are exposed.
+        """
+        config_id = data.get('config_id', '')
+        if not config_id:
+            return {'found': False, 'version': None}
+
+        config = get_external_config_from_filter(
+            {"course_key": self.scope_ids.usage_id.context_key},
+            config_id,
+        )
+        version = config.get("version") if config else None
+        return {'found': version is not None, 'version': version}
 
     def extract_real_user_data(self):
         """
@@ -1215,10 +1229,14 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             if field_info is not None:
                 context["fields"][field_name] = field_info
 
+        # Compute effective LTI version once and reuse for both the template
+        # context override and the JS context below.
+        effective_lti_version = self.get_effective_lti_version()
+
         # Override lti_version display value for external config
         # so Studio shows the effective version from the external config.
         if self.config_type == 'external' and 'lti_version' in context['fields']:
-            context['fields']['lti_version']['value'] = self.get_effective_lti_version()
+            context['fields']['lti_version']['value'] = effective_lti_version
 
         i18n_service = self.runtime.service(self, 'i18n')
 
@@ -1268,7 +1286,9 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                 self.scope_ids.usage_id.course_key
             ),
             "editableFields": self.editable_fields,
-            "effectiveLtiVersion": self.get_effective_lti_version(),
+            "effectiveLtiVersion": effective_lti_version,
+            "currentExternalConfig": self.external_config,
+            "rawLtiVersion": self.lti_version,
         }
 
         statici18n_js_url = self._get_statici18n_js_url()

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -661,7 +661,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         # a new LTI ID before they've added it to advanced settings, but we do want to warn them about it.
         # If we put this check in validate_field_data(), the settings editor wouldn't let them save changes.
         course = self.course
-        if course and self.lti_version == "lti_1p1" and self.lti_id:
+        if course and self.get_effective_lti_version() == "lti_1p1" and self.lti_id:
             lti_passport_ids = [lti_passport.split(':')[0].strip() for lti_passport in course.lti_passports]
             if self.lti_id.strip() not in lti_passport_ids:
                 validation.add(ValidationMessage(ValidationMessage.WARNING, str(
@@ -1109,6 +1109,38 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         return get_lti_consumer(config_id_for_block(self))
 
+    def get_effective_lti_version(self):
+        """
+        Return the effective LTI version for this block.
+
+        When ``config_type`` is ``"external"``, the version is determined
+        by the external re-usable config (via the ``version`` or
+        ``lti_version`` key), not by the block's own ``lti_version`` field.
+        Falls back to ``self.lti_version`` for non-external configs.
+        """
+        if self.config_type != "external":
+            return self.lti_version
+
+        # Runtime import since this will only run in the
+        # Open edX LMS/Studio environments.
+        # pylint: disable=import-outside-toplevel
+        from lti_consumer.filters import get_external_config_from_filter
+
+        config = get_external_config_from_filter(
+            {"course_key": self.scope_ids.usage_id.context_key},
+            self.external_config,
+        )
+        raw_version = config.get("version") or config.get("lti_version")
+        if raw_version is None:
+            return self.lti_version
+
+        # Normalize external version format (LTI_1P1 -> lti_1p1, etc.)
+        if raw_version in ("lti_1p3", "LTI_1P3"):
+            return "lti_1p3"
+        if raw_version in ("lti_1p1", "LTI_1P1"):
+            return "lti_1p1"
+        return raw_version
+
     def extract_real_user_data(self):
         """
         Extract and return real user data from the runtime
@@ -1258,7 +1290,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         If using LTI 1.3 it displays a fragment with parameters that
         need to be set on the LTI Tool to make the integration work.
         """
-        if self.lti_version == "lti_1p1":
+        if self.get_effective_lti_version() == "lti_1p1":
             return self.student_view(context)
 
         # Render template
@@ -1296,7 +1328,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         # Prepend the author view for LTI1.3 when rendering student view to staff users in Studio.
         # This is needed so course staff can see the author view parameters when configuring within Libraries v2
-        if settings.SERVICE_VARIANT != 'lms' and self.lti_version == "lti_1p3" and self.user_is_staff:
+        if settings.SERVICE_VARIANT != 'lms' and self.get_effective_lti_version() == "lti_1p3" and self.user_is_staff:
             self._add_author_view(context, loader, fragment)
 
         fragment.add_content(loader.render_mako_template('/templates/html/student.html', context))
@@ -1423,7 +1455,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             Sucess: https://tools.ietf.org/html/rfc6749#section-4.4.3
             Failure: https://tools.ietf.org/html/rfc6749#section-5.2
         """
-        if self.lti_version != "lti_1p3":
+        if self.get_effective_lti_version() != "lti_1p3":
             return Response(status=404)
 
         # Asserting that the consumer can be created. This makes sure that the LtiConfiguration
@@ -1651,7 +1683,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         # The lti_launch_url property only exists on the LtiConsumer1p1. The LtiConsumer1p3 does not have an
         # attribute with this name, so ensure that we're accessing it on the appropriate consumer class.
-        if consumer and self.config_type in ("database", "external") and self.lti_version == "lti_1p1":
+        if consumer and self.config_type in ("database", "external") and self.get_effective_lti_version() == "lti_1p1":
             launch_url = consumer.lti_launch_url
 
         return launch_url
@@ -1753,7 +1785,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         Return the LTI block launch handler.
         """
-        if self.lti_version == 'lti_1p1':
+        if self.get_effective_lti_version() == 'lti_1p1':
             lti_block_launch_handler = self.runtime.handler_url(self, 'lti_launch_handler').rstrip('/?')
         else:
             launch_data = self.get_lti_1p3_launch_data()
@@ -1774,7 +1806,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         lti_1p3_launch_url = self.lti_1p3_launch_url.strip()
 
         # Get LTI launch URL from consumer if using database or external configuration type.
-        if consumer and self.lti_version == 'lti_1p3' and self.config_type in ('database', 'external'):
+        if consumer and self.get_effective_lti_version() == 'lti_1p3' and self.config_type in ('database', 'external'):
             lti_1p3_launch_url = consumer.launch_url
 
         return lti_1p3_launch_url
@@ -1833,7 +1865,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'modal_horizontal_offset': self._get_modal_position_offset(self.modal_width),
             'modal_width': self.modal_width,
             'accept_grades_past_due': self.accept_grades_past_due,
-            'lti_version': self.lti_version,
+            'lti_version': self.get_effective_lti_version(),
         }
 
     def _get_modal_position_offset(self, viewport_percentage):

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1113,9 +1113,9 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         Return the effective LTI version for this block.
 
-        When ``config_type`` is ``"external"``, the version is determined
-        by the external re-usable config's ``version`` key, not by the
-        block's own ``lti_version`` field.  Falls back to ``self.lti_version``
+        When `config_type` is `"external"`, the version is determined
+        by the external re-usable config's `version` key, not by the
+        block's own `lti_version` field.  Falls back to `self.lti_version`
         for non-external configs or when external config has no version.
         """
         if self.config_type != "external":

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1114,9 +1114,9 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         Return the effective LTI version for this block.
 
         When ``config_type`` is ``"external"``, the version is determined
-        by the external re-usable config (via the ``version`` or
-        ``lti_version`` key), not by the block's own ``lti_version`` field.
-        Falls back to ``self.lti_version`` for non-external configs.
+        by the external re-usable config's ``version`` key, not by the
+        block's own ``lti_version`` field.  Falls back to ``self.lti_version``
+        for non-external configs or when external config has no version.
         """
         if self.config_type != "external":
             return self.lti_version
@@ -1130,16 +1130,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             {"course_key": self.scope_ids.usage_id.context_key},
             self.external_config,
         )
-        raw_version = config.get("version") or config.get("lti_version")
-        if raw_version is None:
-            return self.lti_version
-
-        # Normalize external version format (LTI_1P1 -> lti_1p1, etc.)
-        if raw_version in ("lti_1p3", "LTI_1P3"):
-            return "lti_1p3"
-        if raw_version in ("lti_1p1", "LTI_1P1"):
-            return "lti_1p1"
-        return raw_version
+        return config.get("version") or self.lti_version
 
     def extract_real_user_data(self):
         """

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1215,6 +1215,11 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             if field_info is not None:
                 context["fields"][field_name] = field_info
 
+        # Override lti_version display value for external config
+        # so Studio shows the effective version from the external config.
+        if self.config_type == 'external' and 'lti_version' in context['fields']:
+            context['fields']['lti_version']['value'] = self.get_effective_lti_version()
+
         i18n_service = self.runtime.service(self, 'i18n')
 
         # ResourceLoader renders template from string, not Django loader-backed template.

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1143,7 +1143,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         return config.get("version") or self.lti_version
 
     @XBlock.json_handler
-    def resolve_external_config_version(self, data, suffix=''):
+    def resolve_external_config_version(self, data, suffix=''):  # pylint: disable=unused-argument
         """
         Handler for Studio to resolve the LTI version for a given
         external config ID.  Returns only the version — no secrets

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1110,7 +1110,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         return get_lti_consumer(config_id_for_block(self))
 
-    def get_effective_lti_version(self):
+    def get_resolved_lti_version(self):
         """
         Return the effective LTI version for this block.
 
@@ -1257,7 +1257,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         # Compute effective LTI version once and reuse for both the template
         # context override and the JS context below.
-        effective_lti_version = self.get_effective_lti_version()
+        effective_lti_version = self.get_resolved_lti_version()
 
         # Override lti_version display value for external config
         # so Studio shows the effective version from the external config.
@@ -1333,7 +1333,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         If using LTI 1.3 it displays a fragment with parameters that
         need to be set on the LTI Tool to make the integration work.
         """
-        if self.get_effective_lti_version() == "lti_1p1":
+        if self.get_resolved_lti_version() == "lti_1p1":
             return self.student_view(context)
 
         # Render template
@@ -1371,7 +1371,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         # Prepend the author view for LTI1.3 when rendering student view to staff users in Studio.
         # This is needed so course staff can see the author view parameters when configuring within Libraries v2
-        if settings.SERVICE_VARIANT != 'lms' and self.get_effective_lti_version() == "lti_1p3" and self.user_is_staff:
+        if settings.SERVICE_VARIANT != 'lms' and self.get_resolved_lti_version() == "lti_1p3" and self.user_is_staff:
             self._add_author_view(context, loader, fragment)
 
         fragment.add_content(loader.render_mako_template('/templates/html/student.html', context))
@@ -1498,7 +1498,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             Sucess: https://tools.ietf.org/html/rfc6749#section-4.4.3
             Failure: https://tools.ietf.org/html/rfc6749#section-5.2
         """
-        if self.get_effective_lti_version() != "lti_1p3":
+        if self.get_resolved_lti_version() != "lti_1p3":
             return Response(status=404)
 
         # Asserting that the consumer can be created. This makes sure that the LtiConfiguration
@@ -1726,7 +1726,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
 
         # The lti_launch_url property only exists on the LtiConsumer1p1. The LtiConsumer1p3 does not have an
         # attribute with this name, so ensure that we're accessing it on the appropriate consumer class.
-        if consumer and self.config_type in ("database", "external") and self.get_effective_lti_version() == "lti_1p1":
+        if consumer and self.config_type in ("database", "external") and self.get_resolved_lti_version() == "lti_1p1":
             launch_url = consumer.lti_launch_url
 
         return launch_url
@@ -1828,7 +1828,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         """
         Return the LTI block launch handler.
         """
-        if self.get_effective_lti_version() == 'lti_1p1':
+        if self.get_resolved_lti_version() == 'lti_1p1':
             lti_block_launch_handler = self.runtime.handler_url(self, 'lti_launch_handler').rstrip('/?')
         else:
             launch_data = self.get_lti_1p3_launch_data()
@@ -1849,7 +1849,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         lti_1p3_launch_url = self.lti_1p3_launch_url.strip()
 
         # Get LTI launch URL from consumer if using database or external configuration type.
-        if consumer and self.get_effective_lti_version() == 'lti_1p3' and self.config_type in ('database', 'external'):
+        if consumer and self.get_resolved_lti_version() == 'lti_1p3' and self.config_type in ('database', 'external'):
             lti_1p3_launch_url = consumer.launch_url
 
         return lti_1p3_launch_url
@@ -1908,7 +1908,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'modal_horizontal_offset': self._get_modal_position_offset(self.modal_width),
             'modal_width': self.modal_width,
             'accept_grades_past_due': self.accept_grades_past_due,
-            'lti_version': self.get_effective_lti_version(),
+            'lti_version': self.get_resolved_lti_version(),
         }
 
     def _get_modal_position_offset(self, viewport_percentage):

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -1118,14 +1118,28 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         by the external re-usable config's `version` key, not by the
         block's own `lti_version` field.  Falls back to `self.lti_version`
         for non-external configs or when external config has no version.
+
+        If the external config lookup raises (e.g. filter service
+        unavailable), the exception is logged and the block's own
+        `lti_version` is returned as a safe fallback.
         """
         if self.config_type != "external":
             return self.lti_version
 
-        config = get_external_config_from_filter(
-            {"course_key": self.scope_ids.usage_id.context_key},
-            self.external_config,
-        )
+        try:
+            config = get_external_config_from_filter(
+                {"course_key": self.scope_ids.usage_id.context_key},
+                self.external_config,
+            )
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "Failed to resolve external config version for config_id=%s; "
+                "falling back to block-level lti_version=%s",
+                self.external_config,
+                self.lti_version,
+            )
+            return self.lti_version
+
         return config.get("version") or self.lti_version
 
     @XBlock.json_handler
@@ -1134,15 +1148,27 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         Handler for Studio to resolve the LTI version for a given
         external config ID.  Returns only the version — no secrets
         from the external configuration are exposed.
+
+        If the filter lookup raises (e.g. service unavailable), the
+        exception is logged and a safe fallback response is returned
+        so the Studio UI degrades gracefully.
         """
         config_id = data.get('config_id', '')
         if not config_id:
             return {'found': False, 'version': None}
 
-        config = get_external_config_from_filter(
-            {"course_key": self.scope_ids.usage_id.context_key},
-            config_id,
-        )
+        try:
+            config = get_external_config_from_filter(
+                {"course_key": self.scope_ids.usage_id.context_key},
+                config_id,
+            )
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "Failed to resolve external config version for config_id=%s",
+                config_id,
+            )
+            return {'found': False, 'version': None}
+
         version = config.get("version") if config else None
         return {'found': version is not None, 'version': version}
 

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -742,12 +742,48 @@ class LtiConfiguration(models.Model):
 
         return consumer
 
+    @staticmethod
+    def _normalize_version(version_value):
+        """
+        Normalize external version values to internal format.
+
+        External configs may use ``LTI_1P1`` / ``LTI_1P3`` (ADR 0006 format)
+        or ``lti_1p1`` / ``lti_1p3`` (internal format). This normalizes both
+        to the internal format.
+        """
+        if version_value in (LtiConfiguration.LTI_1P3, 'LTI_1P3'):
+            return LtiConfiguration.LTI_1P3
+        if version_value in (LtiConfiguration.LTI_1P1, 'LTI_1P1'):
+            return LtiConfiguration.LTI_1P1
+        return version_value
+
+    def get_effective_version(self):
+        """
+        Return the effective LTI version for this configuration.
+
+        When ``config_store == CONFIG_EXTERNAL``, checks the external config
+        for a ``version`` or ``lti_version`` key (both formats supported),
+        normalises the value, and returns it.  Falls back to ``self.version``.
+        """
+        if self.config_store == self.CONFIG_EXTERNAL:
+            ext = self.external_config
+            raw = ext.get('version') or ext.get('lti_version')
+            if raw is not None:
+                return self._normalize_version(raw)
+        return self.version
+
     @function_trace('lti_consumer.models.LtiConfiguration.get_lti_consumer')
     def get_lti_consumer(self):
         """
         Returns an instanced class of LTI 1.1 or 1.3 consumer.
+
+        When using external config, the version from the external config
+        takes priority over the locally stored version to avoid version
+        mismatch crashes.
         """
-        if self.version == self.LTI_1P3:
+        effective_version = self.get_effective_version()
+
+        if effective_version == self.LTI_1P3:
             return self._get_lti_1p3_consumer()
 
         return self._get_lti_1p1_consumer()

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -742,34 +742,17 @@ class LtiConfiguration(models.Model):
 
         return consumer
 
-    @staticmethod
-    def _normalize_version(version_value):
-        """
-        Normalize external version values to internal format.
-
-        External configs may use ``LTI_1P1`` / ``LTI_1P3`` (ADR 0006 format)
-        or ``lti_1p1`` / ``lti_1p3`` (internal format). This normalizes both
-        to the internal format.
-        """
-        if version_value in (LtiConfiguration.LTI_1P3, 'LTI_1P3'):
-            return LtiConfiguration.LTI_1P3
-        if version_value in (LtiConfiguration.LTI_1P1, 'LTI_1P1'):
-            return LtiConfiguration.LTI_1P1
-        return version_value
-
     def get_effective_version(self):
         """
         Return the effective LTI version for this configuration.
 
         When ``config_store == CONFIG_EXTERNAL``, checks the external config
-        for a ``version`` or ``lti_version`` key (both formats supported),
-        normalises the value, and returns it.  Falls back to ``self.version``.
+        for a ``version`` key and returns it.  Falls back to ``self.version``.
         """
         if self.config_store == self.CONFIG_EXTERNAL:
-            ext = self.external_config
-            raw = ext.get('version') or ext.get('lti_version')
-            if raw is not None:
-                return self._normalize_version(raw)
+            ext_version = self.external_config.get('version')
+            if ext_version is not None:
+                return ext_version
         return self.version
 
     @function_trace('lti_consumer.models.LtiConfiguration.get_lti_consumer')

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -20,6 +20,10 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
       callback(_versionCache[configId]);
       return;
     }
+    // Global counter bumps on each async version lookup.
+    // Local requestId captures the incremented value via pre-increment.
+    // Later stale-response checks compare local vs global to ignore
+    // responses from superseded requests (see comments below).
     var requestId = ++_versionRequestId;
     var handlerUrl = runtime.handlerUrl(element, "resolve_external_config_version");
 

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -69,9 +69,13 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
     if (configType === "new") {
       toggleFieldVisibility("lti_id", version === "lti_1p1");
       toggleFieldVisibility("external_config", false);
+      toggleFieldVisibility("lti_version", true);
     } else {
       toggleFieldVisibility("lti_id", false);
       toggleFieldVisibility("external_config", true);
+      // Hide LTI version when using reusable/external config;
+      // version is determined by the external config, not the block.
+      toggleFieldVisibility("lti_version", false);
     }
 
     if (configType === "external") {

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -39,10 +39,29 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
   }
 
   /**
+   * Return effective LTI version.
+   * When config_type is external, version is determined by the external
+   * re-usable config, not by the block's own lti_version field.
+   * Falls back to the radio button value otherwise.
+   */
+  function getEffectiveVersion() {
+    let configType;
+    try {
+      configType = getFieldValue("config_type").value || "new";
+    } catch (e) {
+      configType = "new";
+    }
+    if (configType === "external") {
+      return data.effectiveLtiVersion;
+    }
+    return getRadioButtonValue("lti_version");
+  }
+
+  /**
    * Show or hide components depending on the selected lti_version and config_type.
    */
   function toggleLtiComponents() {
-    const version = getRadioButtonValue("lti_version");
+    const version = getEffectiveVersion();
     let configType;
     try {
       configType = getFieldValue("config_type").value || "new";
@@ -338,7 +357,7 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
     .bind("click", function (e) {
       e.preventDefault();
       let nextStep;
-      const version = getRadioButtonValue("lti_version");
+      const version = getEffectiveVersion();
       let configType;
       try {
         configType = getFieldValue("config_type").value || "new";
@@ -366,7 +385,7 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
     .bind("click", function (e) {
       e.preventDefault();
       let previousStep;
-      const version = getRadioButtonValue("lti_version");
+      const version = getEffectiveVersion();
       let configType;
       try {
         configType = getFieldValue("config_type").value || "new";

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -70,12 +70,17 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
       toggleFieldVisibility("lti_id", version === "lti_1p1");
       toggleFieldVisibility("external_config", false);
       toggleFieldVisibility("lti_version", true);
-    } else {
+    } else if (configType === "external") {
       toggleFieldVisibility("lti_id", false);
       toggleFieldVisibility("external_config", true);
       // Hide LTI version when using reusable/external config;
       // version is determined by the external config, not the block.
       toggleFieldVisibility("lti_version", false);
+    } else {
+      // database config — version set per-block, keep visible.
+      toggleFieldVisibility("lti_id", false);
+      toggleFieldVisibility("external_config", false);
+      toggleFieldVisibility("lti_version", true);
     }
 
     if (configType === "external") {

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -562,7 +562,16 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
       const { editableFields } = data;
       const handlerUrl = runtime.handlerUrl(element, "submit_studio_edits");
       const submitData = { values: {}, defaults: [] };
+
+      // When config_type is external, lti_version is determined by the
+      // reusable config — skip submitting it to avoid overwriting the
+      // effective version with a stale radio-button value.
+      const saveConfigType = getFieldValue("config_type").value || "new";
+
       for (const field of editableFields) {
+        if (saveConfigType === "external" && field === "lti_version") {
+          continue;
+        }
         const { isSet, value } = getFieldValue(field);
         if (isSet) {
           submitData.values[field] = value;

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -4,6 +4,46 @@
 function LtiConsumerXBlockInitStudio(runtime, element, data) {
   let currentStep = "setup";
 
+  // Cache for resolved external config versions (config_id -> version|null).
+  var _versionCache = {};
+  var _versionRequestId = 0;
+
+  /**
+   * Resolve the LTI version for a given external config ID via the
+   * server handler.  Caches results to avoid redundant requests.
+   * Calls callback(version) with the resolved version (or null on
+   * failure / unknown ID).  Uses a monotonically increasing request
+   * ID to discard stale responses from earlier requests.
+   */
+  function resolveExternalConfigVersion(configId, callback) {
+    if (_versionCache.hasOwnProperty(configId)) {
+      callback(_versionCache[configId]);
+      return;
+    }
+    var requestId = ++_versionRequestId;
+    var handlerUrl = runtime.handlerUrl(element, "resolve_external_config_version");
+
+    $.ajax({
+      type: "POST",
+      url: handlerUrl,
+      data: JSON.stringify({ config_id: configId }),
+      dataType: "json",
+      contentType: "application/json",
+      global: false,
+      success: function (response) {
+        if (requestId !== _versionRequestId) return; // stale
+        var version = response.found ? response.version : null;
+        _versionCache[configId] = version;
+        callback(version);
+      },
+      error: function () {
+        if (requestId !== _versionRequestId) return; // stale
+        _versionCache[configId] = null;
+        callback(null);
+      },
+    });
+  }
+
   /**
    * Query a field using the `data-field-name` attribute and hide/show it.
    *
@@ -52,7 +92,22 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
       configType = "new";
     }
     if (configType === "external") {
-      return data.effectiveLtiVersion;
+      const extField = getFieldValue("external_config");
+      const extValue = extField.value;
+
+      // 1) Input matches current saved config — use server-resolved version.
+      if (extValue === data.currentExternalConfig) {
+        return data.effectiveLtiVersion;
+      }
+
+      // 2) Check client-side cache from a previous handler response.
+      if (extValue && _versionCache.hasOwnProperty(extValue)) {
+        var cached = _versionCache[extValue];
+        return cached !== null ? cached : data.rawLtiVersion;
+      }
+
+      // 3) Unknown / not yet resolved — use block's stored lti_version.
+      return data.rawLtiVersion;
     }
     return getRadioButtonValue("lti_version");
   }
@@ -328,6 +383,28 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
     .find("[id^=xb-field-edit-config_type]")
     .bind("change", function () {
       toggleLtiComponents();
+    });
+
+  // Bind to change event on external_config input.
+  // Fires once when the user commits a new value (tabs out / clicks away).
+  // Skips lookup for empty or unchanged values.
+  $(element)
+    .find("#xb-field-edit-external_config")
+    .bind("change", function () {
+      const configId = $(this).val();
+      if (!configId || configId === data.currentExternalConfig) {
+        // Empty or unchanged — use effectiveLtiVersion / rawLtiVersion fallback.
+        toggleLtiComponents();
+        return;
+      }
+
+      // Show UI with current fallback immediately while resolving.
+      toggleLtiComponents();
+
+      // Resolve asynchronously, then re-evaluate UI.
+      resolveExternalConfigVersion(configId, function (/* version */) {
+        toggleLtiComponents();
+      });
     });
 
   $(element)

--- a/lti_consumer/templates/html/lti_studio_edit/_step_setup.html
+++ b/lti_consumer/templates/html/lti_studio_edit/_step_setup.html
@@ -33,7 +33,7 @@
             {% endif %}
             <!-------------------------------------->
             <!----------- lti_version ----------->
-            <li class="field comp-setting-entry lti-version {% if fields.lti_version.is_set %}is-set{% endif %}">
+            <li class="field comp-setting-entry lti-version {% if fields.lti_version.is_set %}is-set{% endif %}" data-field-name="lti_version">
                 <label class="label setting-label">{{ fields.lti_version.display_name }}</label>
                 <span class="icon fa fa-question-circle" data-tooltip="{{ fields.lti_version.help }}"></span>
                 <ul class="button-select-options">

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -83,18 +83,6 @@ class TestGetEffectiveLtiVersion(TestLtiConsumerXBlock):
     Tests for LtiConsumerXBlock.get_effective_lti_version().
     """
 
-    def test_returns_lti_version_when_not_external(self):
-        """
-        When config_type is not external, get_effective_lti_version()
-        returns self.lti_version unchanged.
-        """
-        self.xblock.config_type = "new"
-        self.xblock.lti_version = "lti_1p1"
-        self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p1")
-
-        self.xblock.lti_version = "lti_1p3"
-        self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p3")
-
     def test_returns_external_version_key_when_external(self):
         """
         When config_type is external and external config has a "version"
@@ -157,31 +145,10 @@ class TestResolveExternalConfigVersion(TestLtiConsumerXBlock):
             result = self._call_handler('test-plugin:test-id')
             self.assertEqual(result, {'found': True, 'version': 'lti_1p3'})
 
-    def test_returns_no_version_for_config_without_version(self):
-        """Returns found=False when config has no version key."""
-        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
-            mock_filter.return_value = {'lti_1p3_client_id': 'test'}
-            result = self._call_handler('test-plugin:test-id')
-            self.assertEqual(result, {'found': False, 'version': None})
-
-    def test_returns_no_version_for_unknown_config(self):
-        """Returns found=False when config ID is not found."""
-        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
-            mock_filter.return_value = {}
-            result = self._call_handler('nonexistent')
-            self.assertEqual(result, {'found': False, 'version': None})
-
     def test_returns_no_version_for_empty_config_id(self):
         """Returns found=False when config_id is empty; does not call filter."""
         with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
             result = self._call_handler('')
-            self.assertEqual(result, {'found': False, 'version': None})
-            mock_filter.assert_not_called()
-
-    def test_handles_missing_config_id_key(self):
-        """Gracefully handles missing config_id in request body."""
-        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
-            result = self._call_handler(None)
             self.assertEqual(result, {'found': False, 'version': None})
             mock_filter.assert_not_called()
 
@@ -434,31 +401,20 @@ class TestProperties(TestLtiConsumerXBlock):
         self.assertFalse(validation.empty)
 
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
-    def test_validate_lti_id_external_config(self, mock_course):
+    @ddt.data('external', 'database')
+    def test_validate_lti_id_non_new_config(self, config_type, mock_course):
         """
-        Test that external config does NOT trigger LTI passport warning,
-        even when lti_version is lti_1p1 and lti_id is invalid.
+        Non-'new' config types (external, database) should not trigger
+        LTI passport warning even when lti_version=lti_1p1 and lti_id
+        is invalid.
         """
-        self.xblock.config_type = "external"
+        self.xblock.config_type = config_type
         self.xblock.lti_version = "lti_1p1"
-        self.xblock.external_config = "test:x"
+        self.xblock.external_config = "test:x" if config_type == "external" else None
         self.xblock.lti_id = "nonexistent"
         type(mock_course).lti_passports = PropertyMock(return_value=["valid:key:secret"])
         validation = self.xblock.validate()
-        self.assertTrue(validation.empty, "External config should not produce LTI passport warning")
-
-    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
-    def test_validate_lti_id_database_config(self, mock_course):
-        """
-        Test that database config does NOT trigger LTI passport warning,
-        even when lti_version is lti_1p1 and lti_id is invalid.
-        """
-        self.xblock.config_type = "database"
-        self.xblock.lti_version = "lti_1p1"
-        self.xblock.lti_id = "nonexistent"
-        type(mock_course).lti_passports = PropertyMock(return_value=["valid:key:secret"])
-        validation = self.xblock.validate()
-        self.assertTrue(validation.empty, "Database config should not produce LTI passport warning")
+        self.assertTrue(validation.empty, f"{config_type} config should not produce LTI passport warning")
 
     def test_role(self):
         """
@@ -2284,54 +2240,24 @@ class TestLtiConsumer1p3XBlock(TestCase):
             fragment = self.xblock.studio_view({})
             normalized_content = ' '.join(fragment.content.split())
 
-            # The lti_1p3 radio should be checked (sourced from external config)
+            # Effective version radio shown (sourced from external config)
             self.assertIn(
                 'id="lti_version_option-lti_1p3" value="lti_1p3" checked',
                 normalized_content,
             )
-            # The lti_1p1 radio should NOT be checked (stale block value overridden)
-            self.assertNotIn(
-                'id="lti_version_option-lti_1p1" checked',
-                normalized_content,
-            )
 
-            # Verify js_context includes effectiveLtiVersion for JS use
-            self.assertIn(
-                'effectiveLtiVersion',
-                fragment.json_init_args,
-            )
+            # js_context carries effective version, raw fallback, and current config
             self.assertEqual(
                 fragment.json_init_args['effectiveLtiVersion'],
                 'lti_1p3',
-            )
-
-            # Verify js_context includes rawLtiVersion for fallback when
-            # the external config ID is unknown or has no version key.
-            self.assertIn(
-                'rawLtiVersion',
-                fragment.json_init_args,
             )
             self.assertEqual(
                 fragment.json_init_args['rawLtiVersion'],
                 'lti_1p1',
             )
-
-            # Verify js_context includes currentExternalConfig so JS can
-            # detect whether the field has been modified by the user.
-            self.assertIn(
-                'currentExternalConfig',
-                fragment.json_init_args,
-            )
             self.assertEqual(
                 fragment.json_init_args['currentExternalConfig'],
                 'test-plugin:test-id',
-            )
-
-            # Verify js_context does NOT include externalConfigVersions
-            # (replaced by on-demand handler lookups).
-            self.assertNotIn(
-                'externalConfigVersions',
-                fragment.json_init_args,
             )
 
     @patch('lti_consumer.plugin.compat.get_course_by_id')
@@ -2366,15 +2292,10 @@ class TestLtiConsumer1p3XBlock(TestCase):
             # Must not raise.
             fragment = self.xblock.studio_view({})
 
-        # Even with a filter failure, the fragment should render
-        # its JS init args without crashing.
-        self.assertEqual(fragment.js_init_fn, 'LtiConsumerXBlockInitStudio')
-        self.assertIn(
-            'rawLtiVersion',
-            fragment.json_init_args,
-        )
+        # Even with a filter failure, fragment renders and falls back
+        # to the block's own lti_version as effective version.
         self.assertEqual(
-            fragment.json_init_args['rawLtiVersion'],
+            fragment.json_init_args['effectiveLtiVersion'],
             'lti_1p1',
         )
 
@@ -2768,85 +2689,7 @@ class TestLti1p3AccessTokenJWK(TestBaseWithPatch):
         self.assertJSONEqual(response.content, {'error': 'invalid_client'})
 
 
-class TestSubmitStudioEditsHandler(TestLtiConsumerXBlock):
-    """
-    Unit tests for LtiConsumerXBlock.submit_studio_edits()
-    """
 
-    def setUp(self):
-        super().setUp()
-        self.xblock.lti_version = "lti_1p3"
-
-        db_config_waffle_patcher = patch('lti_consumer.lti_xblock.database_config_enabled', return_value=True)
-        db_config_waffle_patcher.start()
-        self.addCleanup(db_config_waffle_patcher.stop)
-
-        external_config_flag_patcher = patch(
-            'lti_consumer.lti_xblock.external_config_filter_enabled',
-            return_value=False
-        )
-        external_config_flag_patcher.start()
-        self.addCleanup(external_config_flag_patcher.stop)
-
-    def _call_submit_studio_edits(self, payload):
-        """Helper: call submit_studio_edits handler with JSON request."""
-        import json
-        request = make_request(json.dumps(payload), 'POST')
-        response = self.xblock.submit_studio_edits(request)
-        return json.loads(response.body)
-
-    def test_external_config_skips_lti_version(self):
-        """
-        When config_type is external, submitting studio edits WITHOUT
-        lti_version in the payload must NOT overwrite the block's
-        stored lti_version.
-
-        The JS in xblock_studio_view.js now skips lti_version from
-        the payload when config_type === 'external' (the version is
-        determined by the reusable config). This test validates the
-        Python handler's contract: it only sets fields present in
-        data['values'].
-        """
-        self.xblock.config_type = 'external'
-        self.xblock.external_config = 'test-plugin:test-id'
-        self.xblock.lti_version = 'lti_1p3'
-
-        # Simulate fixed-JS payload: config_type set, lti_version omitted.
-        payload = {
-            'values': {'config_type': 'external'},
-            'defaults': [],
-        }
-        with patch('lti_consumer.lti_xblock.external_config_filter_enabled', return_value=True):
-            result = self._call_submit_studio_edits(payload)
-
-        self.assertEqual(result, {'result': 'success'})
-        # lti_version must remain unchanged.
-        self.assertEqual(self.xblock.lti_version, 'lti_1p3')
-
-    def test_external_config_lti_version_not_overwritten_when_omitted(self):
-        """
-        When studio edits include config_type='external' and also
-        include other fields (like display_name) but NOT lti_version,
-        the block's stored lti_version must survive unchanged.
-        """
-        self.xblock.config_type = 'external'
-        self.xblock.external_config = 'test-plugin:test-id'
-        self.xblock.lti_version = 'lti_1p1'
-        self.xblock.display_name = 'Original Name'
-
-        payload = {
-            'values': {
-                'config_type': 'external',
-                'display_name': 'Updated Name',
-            },
-            'defaults': [],
-        }
-        with patch('lti_consumer.lti_xblock.external_config_filter_enabled', return_value=True):
-            result = self._call_submit_studio_edits(payload)
-
-        self.assertEqual(result, {'result': 'success'})
-        self.assertEqual(self.xblock.lti_version, 'lti_1p1')
-        self.assertEqual(self.xblock.display_name, 'Updated Name')
 
 
 @ddt.ddt

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -80,7 +80,7 @@ class TestLtiConsumerXBlock(TestBaseWithPatch):
 
 class TestGetEffectiveLtiVersion(TestLtiConsumerXBlock):
     """
-    Tests for LtiConsumerXBlock.get_effective_lti_version().
+    Tests for LtiConsumerXBlock.get_resolved_lti_version().
     """
 
     def test_returns_external_version_key_when_external(self):
@@ -94,7 +94,7 @@ class TestGetEffectiveLtiVersion(TestLtiConsumerXBlock):
 
         with patch("lti_consumer.lti_xblock.get_external_config_from_filter") as mock_filter:
             mock_filter.return_value = {"version": "lti_1p3"}
-            self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p3")
+            self.assertEqual(self.xblock.get_resolved_lti_version(), "lti_1p3")
             mock_filter.assert_called_once()
 
     def test_falls_back_to_lti_version_when_no_external_version(self):
@@ -108,7 +108,7 @@ class TestGetEffectiveLtiVersion(TestLtiConsumerXBlock):
 
         with patch("lti_consumer.lti_xblock.get_external_config_from_filter") as mock_filter:
             mock_filter.return_value = {"lti_1p3_client_id": "test"}
-            self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p1")
+            self.assertEqual(self.xblock.get_resolved_lti_version(), "lti_1p1")
 
     def test_falls_back_on_filter_exception(self):
         """
@@ -121,7 +121,7 @@ class TestGetEffectiveLtiVersion(TestLtiConsumerXBlock):
 
         with patch("lti_consumer.lti_xblock.get_external_config_from_filter") as mock_filter:
             mock_filter.side_effect = Exception("Filter service unavailable")
-            version = self.xblock.get_effective_lti_version()
+            version = self.xblock.get_resolved_lti_version()
             self.assertEqual(version, "lti_1p1")
 
 

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -132,11 +132,10 @@ class TestResolveExternalConfigVersion(TestLtiConsumerXBlock):
 
     def _call_handler(self, config_id):
         """Helper: build a JSON POST request, call handler, parse JSON body."""
-        import json
         body = json.dumps({'config_id': config_id}) if config_id is not None else '{}'
         request = make_request(body, 'POST')
         response = self.xblock.resolve_external_config_version(request)
-        return json.loads(response.body)
+        return json.loads(response.body)  # pylint: disable=no-member
 
     def test_returns_version_for_known_config(self):
         """Returns version when config ID exists and has a version key."""
@@ -2687,9 +2686,6 @@ class TestLti1p3AccessTokenJWK(TestBaseWithPatch):
         response = self.xblock.lti_1p3_access_token(self.request)
         self.assertEqual(response.status_code, 400)
         self.assertJSONEqual(response.content, {'error': 'invalid_client'})
-
-
-
 
 
 @ddt.ddt

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -104,7 +104,7 @@ class TestGetEffectiveLtiVersion(TestLtiConsumerXBlock):
         self.xblock.external_config = "test-plugin:test-id"
         self.xblock.lti_version = "lti_1p1"
 
-        with patch("lti_consumer.filters.get_external_config_from_filter") as mock_filter:
+        with patch("lti_consumer.lti_xblock.get_external_config_from_filter") as mock_filter:
             mock_filter.return_value = {"version": "lti_1p3"}
             self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p3")
             mock_filter.assert_called_once()
@@ -118,9 +118,58 @@ class TestGetEffectiveLtiVersion(TestLtiConsumerXBlock):
         self.xblock.external_config = "test-plugin:test-id"
         self.xblock.lti_version = "lti_1p1"
 
-        with patch("lti_consumer.filters.get_external_config_from_filter") as mock_filter:
+        with patch("lti_consumer.lti_xblock.get_external_config_from_filter") as mock_filter:
             mock_filter.return_value = {"lti_1p3_client_id": "test"}
             self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p1")
+
+
+class TestResolveExternalConfigVersion(TestLtiConsumerXBlock):
+    """
+    Tests for LtiConsumerXBlock.resolve_external_config_version().
+    """
+
+    def _call_handler(self, config_id):
+        """Helper: build a JSON POST request, call handler, parse JSON body."""
+        import json
+        body = json.dumps({'config_id': config_id}) if config_id is not None else '{}'
+        request = make_request(body, 'POST')
+        response = self.xblock.resolve_external_config_version(request)
+        return json.loads(response.body)
+
+    def test_returns_version_for_known_config(self):
+        """Returns version when config ID exists and has a version key."""
+        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
+            mock_filter.return_value = {'version': 'lti_1p3'}
+            result = self._call_handler('test-plugin:test-id')
+            self.assertEqual(result, {'found': True, 'version': 'lti_1p3'})
+
+    def test_returns_no_version_for_config_without_version(self):
+        """Returns found=False when config has no version key."""
+        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
+            mock_filter.return_value = {'lti_1p3_client_id': 'test'}
+            result = self._call_handler('test-plugin:test-id')
+            self.assertEqual(result, {'found': False, 'version': None})
+
+    def test_returns_no_version_for_unknown_config(self):
+        """Returns found=False when config ID is not found."""
+        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
+            mock_filter.return_value = {}
+            result = self._call_handler('nonexistent')
+            self.assertEqual(result, {'found': False, 'version': None})
+
+    def test_returns_no_version_for_empty_config_id(self):
+        """Returns found=False when config_id is empty; does not call filter."""
+        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
+            result = self._call_handler('')
+            self.assertEqual(result, {'found': False, 'version': None})
+            mock_filter.assert_not_called()
+
+    def test_handles_missing_config_id_key(self):
+        """Gracefully handles missing config_id in request body."""
+        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
+            result = self._call_handler(None)
+            self.assertEqual(result, {'found': False, 'version': None})
+            mock_filter.assert_not_called()
 
 
 class TestAddXmlToNode(TestCase):
@@ -344,8 +393,11 @@ class TestProperties(TestLtiConsumerXBlock):
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
     def test_validate_lti_id(self, mock_course):
         """
-        Test `lti_id` returns a warning if it's not set as an LTI passport in the course
+        Test `lti_id` returns a warning if it's not set as an LTI passport in the course.
+        Only applies when config_type is "new" and lti_version is "lti_1p1".
         """
+        self.xblock.config_type = "new"
+        self.xblock.lti_version = "lti_1p1"
         valid_provider = 'lti_provider'
         self.xblock.lti_id = valid_provider
         type(mock_course).lti_passports = PropertyMock(return_value=[f"{valid_provider}:key:secret"])
@@ -355,6 +407,33 @@ class TestProperties(TestLtiConsumerXBlock):
         self.xblock.lti_id = "nonexistent"
         validation = self.xblock.validate()
         self.assertFalse(validation.empty)
+
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
+    def test_validate_lti_id_external_config(self, mock_course):
+        """
+        Test that external config does NOT trigger LTI passport warning,
+        even when lti_version is lti_1p1 and lti_id is invalid.
+        """
+        self.xblock.config_type = "external"
+        self.xblock.lti_version = "lti_1p1"
+        self.xblock.external_config = "test:x"
+        self.xblock.lti_id = "nonexistent"
+        type(mock_course).lti_passports = PropertyMock(return_value=["valid:key:secret"])
+        validation = self.xblock.validate()
+        self.assertTrue(validation.empty, "External config should not produce LTI passport warning")
+
+    @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.course')
+    def test_validate_lti_id_database_config(self, mock_course):
+        """
+        Test that database config does NOT trigger LTI passport warning,
+        even when lti_version is lti_1p1 and lti_id is invalid.
+        """
+        self.xblock.config_type = "database"
+        self.xblock.lti_version = "lti_1p1"
+        self.xblock.lti_id = "nonexistent"
+        type(mock_course).lti_passports = PropertyMock(return_value=["valid:key:secret"])
+        validation = self.xblock.validate()
+        self.assertTrue(validation.empty, "Database config should not produce LTI passport warning")
 
     def test_role(self):
         """
@@ -2175,9 +2254,8 @@ class TestLtiConsumer1p3XBlock(TestCase):
         self.xblock.external_config = 'test-plugin:test-id'
         self.xblock.lti_version = 'lti_1p1'
 
-        with patch('lti_consumer.filters.get_external_config_from_filter') as mock_filter:
-            mock_filter.return_value = {'version': 'lti_1p3'}
-
+        with patch('lti_consumer.lti_xblock.get_external_config_from_filter',
+                   return_value={'version': 'lti_1p3'}):
             fragment = self.xblock.studio_view({})
             normalized_content = ' '.join(fragment.content.split())
 
@@ -2200,6 +2278,35 @@ class TestLtiConsumer1p3XBlock(TestCase):
             self.assertEqual(
                 fragment.json_init_args['effectiveLtiVersion'],
                 'lti_1p3',
+            )
+
+            # Verify js_context includes rawLtiVersion for fallback when
+            # the external config ID is unknown or has no version key.
+            self.assertIn(
+                'rawLtiVersion',
+                fragment.json_init_args,
+            )
+            self.assertEqual(
+                fragment.json_init_args['rawLtiVersion'],
+                'lti_1p1',
+            )
+
+            # Verify js_context includes currentExternalConfig so JS can
+            # detect whether the field has been modified by the user.
+            self.assertIn(
+                'currentExternalConfig',
+                fragment.json_init_args,
+            )
+            self.assertEqual(
+                fragment.json_init_args['currentExternalConfig'],
+                'test-plugin:test-id',
+            )
+
+            # Verify js_context does NOT include externalConfigVersions
+            # (replaced by on-demand handler lookups).
+            self.assertNotIn(
+                'externalConfigVersions',
+                fragment.json_init_args,
             )
 
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_1p3_launch_data')

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -109,23 +109,10 @@ class TestGetEffectiveLtiVersion(TestLtiConsumerXBlock):
             self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p3")
             mock_filter.assert_called_once()
 
-    def test_returns_external_lti_version_key_when_external(self):
-        """
-        When config_type is external and external config uses the
-        ``lti_version`` key (ADR 0006 format), that version takes priority.
-        """
-        self.xblock.config_type = "external"
-        self.xblock.external_config = "test-plugin:test-id"
-        self.xblock.lti_version = "lti_1p1"
-
-        with patch("lti_consumer.filters.get_external_config_from_filter") as mock_filter:
-            mock_filter.return_value = {"lti_version": "LTI_1P3"}
-            self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p3")
-
     def test_falls_back_to_lti_version_when_no_external_version(self):
         """
-        When external config has neither "version" nor "lti_version" key,
-        fall back to self.lti_version.
+        When external config has no "version" key, fall back to
+        self.lti_version.
         """
         self.xblock.config_type = "external"
         self.xblock.external_config = "test-plugin:test-id"

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -122,6 +122,20 @@ class TestGetEffectiveLtiVersion(TestLtiConsumerXBlock):
             mock_filter.return_value = {"lti_1p3_client_id": "test"}
             self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p1")
 
+    def test_falls_back_on_filter_exception(self):
+        """
+        When get_external_config_from_filter raises, fall back to
+        self.lti_version instead of propagating the exception.
+        """
+        self.xblock.config_type = "external"
+        self.xblock.external_config = "test-plugin:test-id"
+        self.xblock.lti_version = "lti_1p1"
+
+        with patch("lti_consumer.lti_xblock.get_external_config_from_filter") as mock_filter:
+            mock_filter.side_effect = Exception("Filter service unavailable")
+            version = self.xblock.get_effective_lti_version()
+            self.assertEqual(version, "lti_1p1")
+
 
 class TestResolveExternalConfigVersion(TestLtiConsumerXBlock):
     """
@@ -170,6 +184,17 @@ class TestResolveExternalConfigVersion(TestLtiConsumerXBlock):
             result = self._call_handler(None)
             self.assertEqual(result, {'found': False, 'version': None})
             mock_filter.assert_not_called()
+
+    def test_graceful_on_filter_exception(self):
+        """
+        When get_external_config_from_filter raises, handler returns
+        {'found': False, 'version': None} instead of 500.
+        """
+        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
+            mock_filter.side_effect = Exception("Filter service unavailable")
+            result = self._call_handler('test-plugin:test-id')
+            self.assertEqual(result, {'found': False, 'version': None})
+            mock_filter.assert_called_once()
 
 
 class TestAddXmlToNode(TestCase):
@@ -2309,6 +2334,50 @@ class TestLtiConsumer1p3XBlock(TestCase):
                 fragment.json_init_args,
             )
 
+    @patch('lti_consumer.plugin.compat.get_course_by_id')
+    def test_studio_view_graceful_on_filter_error(self, mock_get_course_by_id):
+        """
+        studio_view must not crash when get_external_config_from_filter
+        raises; it should degrade gracefully by showing the block's
+        raw lti_version.
+        """
+        mock_i18n_service = gettext.NullTranslations()
+        mock_i18n_service.ugettext = mock_i18n_service.gettext
+
+        def runtime_service_side_effect(_block, service_name):
+            if service_name == 'i18n':
+                return mock_i18n_service
+            return None
+
+        self.xblock.runtime.service.side_effect = runtime_service_side_effect
+
+        mock_course = Mock()
+        mock_course.display_name_with_default = "DemoX"
+        mock_course.display_org_with_default = "edX"
+        mock_course.lti_passports = ["lti_passport_name:key:secret"]
+        mock_get_course_by_id.return_value = mock_course
+
+        self.xblock.config_type = 'external'
+        self.xblock.external_config = 'test-plugin:test-id'
+        self.xblock.lti_version = 'lti_1p1'
+
+        with patch('lti_consumer.lti_xblock.get_external_config_from_filter') as mock_filter:
+            mock_filter.side_effect = Exception("Filter service unavailable")
+            # Must not raise.
+            fragment = self.xblock.studio_view({})
+
+        # Even with a filter failure, the fragment should render
+        # its JS init args without crashing.
+        self.assertEqual(fragment.js_init_fn, 'LtiConsumerXBlockInitStudio')
+        self.assertIn(
+            'rawLtiVersion',
+            fragment.json_init_args,
+        )
+        self.assertEqual(
+            fragment.json_init_args['rawLtiVersion'],
+            'lti_1p1',
+        )
+
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_1p3_launch_data')
     @patch('lti_consumer.api.get_lti_1p3_launch_info')
     def test_author_view(self, mock_get_launch_info, mock_lti_get_1p3_launch_data):
@@ -2718,6 +2787,66 @@ class TestSubmitStudioEditsHandler(TestLtiConsumerXBlock):
         )
         external_config_flag_patcher.start()
         self.addCleanup(external_config_flag_patcher.stop)
+
+    def _call_submit_studio_edits(self, payload):
+        """Helper: call submit_studio_edits handler with JSON request."""
+        import json
+        request = make_request(json.dumps(payload), 'POST')
+        response = self.xblock.submit_studio_edits(request)
+        return json.loads(response.body)
+
+    def test_external_config_skips_lti_version(self):
+        """
+        When config_type is external, submitting studio edits WITHOUT
+        lti_version in the payload must NOT overwrite the block's
+        stored lti_version.
+
+        The JS in xblock_studio_view.js now skips lti_version from
+        the payload when config_type === 'external' (the version is
+        determined by the reusable config). This test validates the
+        Python handler's contract: it only sets fields present in
+        data['values'].
+        """
+        self.xblock.config_type = 'external'
+        self.xblock.external_config = 'test-plugin:test-id'
+        self.xblock.lti_version = 'lti_1p3'
+
+        # Simulate fixed-JS payload: config_type set, lti_version omitted.
+        payload = {
+            'values': {'config_type': 'external'},
+            'defaults': [],
+        }
+        with patch('lti_consumer.lti_xblock.external_config_filter_enabled', return_value=True):
+            result = self._call_submit_studio_edits(payload)
+
+        self.assertEqual(result, {'result': 'success'})
+        # lti_version must remain unchanged.
+        self.assertEqual(self.xblock.lti_version, 'lti_1p3')
+
+    def test_external_config_lti_version_not_overwritten_when_omitted(self):
+        """
+        When studio edits include config_type='external' and also
+        include other fields (like display_name) but NOT lti_version,
+        the block's stored lti_version must survive unchanged.
+        """
+        self.xblock.config_type = 'external'
+        self.xblock.external_config = 'test-plugin:test-id'
+        self.xblock.lti_version = 'lti_1p1'
+        self.xblock.display_name = 'Original Name'
+
+        payload = {
+            'values': {
+                'config_type': 'external',
+                'display_name': 'Updated Name',
+            },
+            'defaults': [],
+        }
+        with patch('lti_consumer.lti_xblock.external_config_filter_enabled', return_value=True):
+            result = self._call_submit_studio_edits(payload)
+
+        self.assertEqual(result, {'result': 'success'})
+        self.assertEqual(self.xblock.lti_version, 'lti_1p1')
+        self.assertEqual(self.xblock.display_name, 'Updated Name')
 
 
 @ddt.ddt

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -2147,6 +2147,51 @@ class TestLtiConsumer1p3XBlock(TestCase):
             normalized_content,
         )
 
+    @patch('lti_consumer.plugin.compat.get_course_by_id')
+    def test_studio_view_external_config_shows_effective_version(self, mock_get_course_by_id):
+        """
+        Test that studio_view displays the effective LTI version from
+        the external config, not the raw block lti_version field.
+        """
+        # Mock runtime services used by studio view
+        mock_i18n_service = gettext.NullTranslations()
+        mock_i18n_service.ugettext = mock_i18n_service.gettext
+
+        def runtime_service_side_effect(_block, service_name):
+            if service_name == 'i18n':
+                return mock_i18n_service
+            return None
+
+        self.xblock.runtime.service.side_effect = runtime_service_side_effect
+
+        mock_course = Mock()
+        mock_course.display_name_with_default = "DemoX"
+        mock_course.display_org_with_default = "edX"
+        mock_course.lti_passports = ["lti_passport_name:key:secret"]
+        mock_get_course_by_id.return_value = mock_course
+
+        # Configure block for external config with stale raw lti_version
+        self.xblock.config_type = 'external'
+        self.xblock.external_config = 'test-plugin:test-id'
+        self.xblock.lti_version = 'lti_1p1'
+
+        with patch('lti_consumer.filters.get_external_config_from_filter') as mock_filter:
+            mock_filter.return_value = {'version': 'lti_1p3'}
+
+            fragment = self.xblock.studio_view({})
+            normalized_content = ' '.join(fragment.content.split())
+
+            # The lti_1p3 radio should be checked (sourced from external config)
+            self.assertIn(
+                'id="lti_version_option-lti_1p3" value="lti_1p3" checked',
+                normalized_content,
+            )
+            # The lti_1p1 radio should NOT be checked (stale block value overridden)
+            self.assertNotIn(
+                'id="lti_version_option-lti_1p1" checked',
+                normalized_content,
+            )
+
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_1p3_launch_data')
     @patch('lti_consumer.api.get_lti_1p3_launch_info')
     def test_author_view(self, mock_get_launch_info, mock_lti_get_1p3_launch_data):

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -2192,6 +2192,16 @@ class TestLtiConsumer1p3XBlock(TestCase):
                 normalized_content,
             )
 
+            # Verify js_context includes effectiveLtiVersion for JS use
+            self.assertIn(
+                'effectiveLtiVersion',
+                fragment.json_init_args,
+            )
+            self.assertEqual(
+                fragment.json_init_args['effectiveLtiVersion'],
+                'lti_1p3',
+            )
+
     @patch('lti_consumer.lti_xblock.LtiConsumerXBlock.get_lti_1p3_launch_data')
     @patch('lti_consumer.api.get_lti_1p3_launch_info')
     def test_author_view(self, mock_get_launch_info, mock_lti_get_1p3_launch_data):

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -78,6 +78,64 @@ class TestLtiConsumerXBlock(TestBaseWithPatch):
         self.compat.get_user_course_forum_role.return_value = None
 
 
+class TestGetEffectiveLtiVersion(TestLtiConsumerXBlock):
+    """
+    Tests for LtiConsumerXBlock.get_effective_lti_version().
+    """
+
+    def test_returns_lti_version_when_not_external(self):
+        """
+        When config_type is not external, get_effective_lti_version()
+        returns self.lti_version unchanged.
+        """
+        self.xblock.config_type = "new"
+        self.xblock.lti_version = "lti_1p1"
+        self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p1")
+
+        self.xblock.lti_version = "lti_1p3"
+        self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p3")
+
+    def test_returns_external_version_key_when_external(self):
+        """
+        When config_type is external and external config has a "version"
+        key, that version takes priority over self.lti_version.
+        """
+        self.xblock.config_type = "external"
+        self.xblock.external_config = "test-plugin:test-id"
+        self.xblock.lti_version = "lti_1p1"
+
+        with patch("lti_consumer.filters.get_external_config_from_filter") as mock_filter:
+            mock_filter.return_value = {"version": "lti_1p3"}
+            self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p3")
+            mock_filter.assert_called_once()
+
+    def test_returns_external_lti_version_key_when_external(self):
+        """
+        When config_type is external and external config uses the
+        ``lti_version`` key (ADR 0006 format), that version takes priority.
+        """
+        self.xblock.config_type = "external"
+        self.xblock.external_config = "test-plugin:test-id"
+        self.xblock.lti_version = "lti_1p1"
+
+        with patch("lti_consumer.filters.get_external_config_from_filter") as mock_filter:
+            mock_filter.return_value = {"lti_version": "LTI_1P3"}
+            self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p3")
+
+    def test_falls_back_to_lti_version_when_no_external_version(self):
+        """
+        When external config has neither "version" nor "lti_version" key,
+        fall back to self.lti_version.
+        """
+        self.xblock.config_type = "external"
+        self.xblock.external_config = "test-plugin:test-id"
+        self.xblock.lti_version = "lti_1p1"
+
+        with patch("lti_consumer.filters.get_external_config_from_filter") as mock_filter:
+            mock_filter.return_value = {"lti_1p3_client_id": "test"}
+            self.assertEqual(self.xblock.get_effective_lti_version(), "lti_1p1")
+
+
 class TestAddXmlToNode(TestCase):
     """Unit tests for export XML on LtiConsumerXBlock."""
 

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -166,43 +166,33 @@ class TestLtiConfigurationModel(TestBaseWithPatch):
         mock_1p3.assert_called_once()
         mock_1p1.assert_not_called()
 
-    @ddt.data(
-        # (stored_version, ext_config, expected_version, suffix)
-        (LtiConfiguration.LTI_1P1, {}, LtiConfiguration.LTI_1P1, 'a'),
-        (LtiConfiguration.LTI_1P3, {}, LtiConfiguration.LTI_1P3, 'b'),
-        (LtiConfiguration.LTI_1P1, {"version": "lti_1p3"}, LtiConfiguration.LTI_1P3, 'c'),
-        (LtiConfiguration.LTI_1P3, {"version": "lti_1p1"}, LtiConfiguration.LTI_1P1, 'd'),
-    )
-    @ddt.unpack
     @patch("lti_consumer.models.get_external_config_from_filter")
-    def test_get_effective_version(
-        self, stored_version, ext_config, expected_version, suffix, mock_filter
+    def test_get_effective_version_falls_back_on_external_without_version(
+        self, mock_filter
     ):
         """
-        Test get_effective_version returns correct version for
-        various external config scenarios.
+        External config without a "version" key falls back to the
+        stored version field.
         """
-        mock_filter.return_value = ext_config
+        mock_filter.return_value = {"lti_1p3_client_id": "test"}
         config = LtiConfiguration.objects.create(
-            version=stored_version,
+            version=LtiConfiguration.LTI_1P1,
             config_store=LtiConfiguration.CONFIG_EXTERNAL,
             external_id="test:x",
-            # Use unique dummy location to avoid UNIQUE constraint collisions
-            location=f'block-v1:course+test+2020+type@problem+block@effver-{suffix}',
+            location='block-v1:course+test+2020+type@problem+block@effver-fallback',
         )
-        self.assertEqual(config.get_effective_version(), expected_version)
+        self.assertEqual(config.get_effective_version(), LtiConfiguration.LTI_1P1)
 
     def test_get_effective_version_non_external(self):
         """
-        Test get_effective_version returns stored version when
-        config_store is not external.
+        Non-external config_store returns the stored version directly.
         """
         config = LtiConfiguration.objects.create(
-            version=LtiConfiguration.LTI_1P1,
+            version=LtiConfiguration.LTI_1P3,
             config_store=LtiConfiguration.CONFIG_ON_XBLOCK,
             location='block-v1:course+test+2020+type@problem+block@effver-non-ext',
         )
-        self.assertEqual(config.get_effective_version(), LtiConfiguration.LTI_1P1)
+        self.assertEqual(config.get_effective_version(), LtiConfiguration.LTI_1P3)
 
     def test_repr(self):
         """

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -142,6 +142,98 @@ class TestLtiConfigurationModel(TestBaseWithPatch):
         self.assertEqual(self.lti_1p1_external.get_lti_consumer(), "consumer")
         mock_consumer.assert_called_once_with("https://example.com", "client_key", "secret")
 
+    @patch("lti_consumer.models.LtiConfiguration._get_lti_1p3_consumer")
+    @patch("lti_consumer.models.LtiConfiguration._get_lti_1p1_consumer")
+    @patch("lti_consumer.models.get_external_config_from_filter")
+    def test_get_lti_consumer_external_config_version_takes_priority(
+        self, mock_filter, mock_1p1, mock_1p3
+    ):
+        """
+        When config_store is external, the version from external config
+        should take priority over the stored version field.
+        """
+        # External config returns LTI 1.3, even though local version is LTI 1.1
+        mock_filter.return_value = {
+            "version": LtiConfiguration.LTI_1P3,
+            "lti_1p3_client_id": "test-client",
+        }
+        mock_1p3.return_value = "lti_1p3_consumer"
+        mock_1p1.return_value = "lti_1p1_consumer"
+
+        result = self.lti_1p1_external.get_lti_consumer()
+
+        self.assertEqual(result, "lti_1p3_consumer")
+        mock_1p3.assert_called_once()
+        mock_1p1.assert_not_called()
+
+    def test_normalize_version(self):
+        """
+        Test that _normalize_version handles all external version formats.
+        """
+        # Internal format passed through
+        self.assertEqual(
+            LtiConfiguration._normalize_version("lti_1p1"),
+            LtiConfiguration.LTI_1P1
+        )
+        self.assertEqual(
+            LtiConfiguration._normalize_version("lti_1p3"),
+            LtiConfiguration.LTI_1P3
+        )
+        # ADR 0006 format (LTI_1P1 / LTI_1P3)
+        self.assertEqual(
+            LtiConfiguration._normalize_version("LTI_1P1"),
+            LtiConfiguration.LTI_1P1
+        )
+        self.assertEqual(
+            LtiConfiguration._normalize_version("LTI_1P3"),
+            LtiConfiguration.LTI_1P3
+        )
+        # Unknown value passed through
+        self.assertEqual(
+            LtiConfiguration._normalize_version("unknown"),
+            "unknown"
+        )
+
+    @ddt.data(
+        # (stored_version, ext_config, expected_version, suffix)
+        (LtiConfiguration.LTI_1P1, {}, LtiConfiguration.LTI_1P1, 'a'),
+        (LtiConfiguration.LTI_1P3, {}, LtiConfiguration.LTI_1P3, 'b'),
+        (LtiConfiguration.LTI_1P1, {"version": "lti_1p3"}, LtiConfiguration.LTI_1P3, 'c'),
+        (LtiConfiguration.LTI_1P3, {"version": "lti_1p1"}, LtiConfiguration.LTI_1P1, 'd'),
+        (LtiConfiguration.LTI_1P1, {"lti_version": "LTI_1P3"}, LtiConfiguration.LTI_1P3, 'e'),
+        (LtiConfiguration.LTI_1P3, {"lti_version": "LTI_1P1"}, LtiConfiguration.LTI_1P1, 'f'),
+    )
+    @ddt.unpack
+    @patch("lti_consumer.models.get_external_config_from_filter")
+    def test_get_effective_version(
+        self, stored_version, ext_config, expected_version, suffix, mock_filter
+    ):
+        """
+        Test get_effective_version returns correct version for
+        various external config scenarios.
+        """
+        mock_filter.return_value = ext_config
+        config = LtiConfiguration.objects.create(
+            version=stored_version,
+            config_store=LtiConfiguration.CONFIG_EXTERNAL,
+            external_id="test:x",
+            # Use unique dummy location to avoid UNIQUE constraint collisions
+            location=f'block-v1:course+test+2020+type@problem+block@effver-{suffix}',
+        )
+        self.assertEqual(config.get_effective_version(), expected_version)
+
+    def test_get_effective_version_non_external(self):
+        """
+        Test get_effective_version returns stored version when
+        config_store is not external.
+        """
+        config = LtiConfiguration.objects.create(
+            version=LtiConfiguration.LTI_1P1,
+            config_store=LtiConfiguration.CONFIG_ON_XBLOCK,
+            location='block-v1:course+test+2020+type@problem+block@effver-non-ext',
+        )
+        self.assertEqual(config.get_effective_version(), LtiConfiguration.LTI_1P1)
+
     def test_repr(self):
         """
         Test String representation of model.

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -166,42 +166,12 @@ class TestLtiConfigurationModel(TestBaseWithPatch):
         mock_1p3.assert_called_once()
         mock_1p1.assert_not_called()
 
-    def test_normalize_version(self):
-        """
-        Test that _normalize_version handles all external version formats.
-        """
-        # Internal format passed through
-        self.assertEqual(
-            LtiConfiguration._normalize_version("lti_1p1"),
-            LtiConfiguration.LTI_1P1
-        )
-        self.assertEqual(
-            LtiConfiguration._normalize_version("lti_1p3"),
-            LtiConfiguration.LTI_1P3
-        )
-        # ADR 0006 format (LTI_1P1 / LTI_1P3)
-        self.assertEqual(
-            LtiConfiguration._normalize_version("LTI_1P1"),
-            LtiConfiguration.LTI_1P1
-        )
-        self.assertEqual(
-            LtiConfiguration._normalize_version("LTI_1P3"),
-            LtiConfiguration.LTI_1P3
-        )
-        # Unknown value passed through
-        self.assertEqual(
-            LtiConfiguration._normalize_version("unknown"),
-            "unknown"
-        )
-
     @ddt.data(
         # (stored_version, ext_config, expected_version, suffix)
         (LtiConfiguration.LTI_1P1, {}, LtiConfiguration.LTI_1P1, 'a'),
         (LtiConfiguration.LTI_1P3, {}, LtiConfiguration.LTI_1P3, 'b'),
         (LtiConfiguration.LTI_1P1, {"version": "lti_1p3"}, LtiConfiguration.LTI_1P3, 'c'),
         (LtiConfiguration.LTI_1P3, {"version": "lti_1p1"}, LtiConfiguration.LTI_1P1, 'd'),
-        (LtiConfiguration.LTI_1P1, {"lti_version": "LTI_1P3"}, LtiConfiguration.LTI_1P3, 'e'),
-        (LtiConfiguration.LTI_1P3, {"lti_version": "LTI_1P1"}, LtiConfiguration.LTI_1P1, 'f'),
     )
     @ddt.unpack
     @patch("lti_consumer.models.get_external_config_from_filter")


### PR DESCRIPTION
**Description:**

- use effective LTI version from reusable external config in `lti_consumer/lti_xblock.py` and `lti_consumer/models.py`
- keep Studio UI in sync in `lti_consumer/static/js/xblock_studio_view.js`
- hide `lti_version` for `config_type=external` and stop Studio save from overwriting stale block value
- add graceful fallback when external config lookup fails
- limit LTI passport warning to `config_type="new"`

**Supporting info:**

* Related ticket: https://github.com/openedx/xblock-lti-consumer/issues/657
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4346

**Test instructions:**

1. Create LTI block with `config_type="external"` and reusable config whose `version` is `lti_1p3`, while block `lti_version` is `lti_1p1`.
2. Open Studio editor. Verify effective version shows as LTI 1.3.
3. Verify `lti_version` field is hidden for `config_type="external"`.
4. Switch to `config_type="database"`. Verify `lti_version` field is visible.
5. Change external config ID to another config with different version. Blur field. Verify Studio fields update to match resolved version.
6. Save block. Re-open editor. Verify save did not overwrite stale block `lti_version` for external config.
7. Launch block. Verify correct LTI 1.1 vs 1.3 flow uses external config version.
8. Break external config lookup. Verify Studio still loads and falls back without crashing.
9. For `config_type="external"` and `config_type="database"`, verify invalid `lti_id` does not show passport warning.
10. For `config_type="new"` + LTI 1.1, verify passport warning behavior stays unchanged.

**AI disclaimer:**

Used GPT 5.4 (xhigh)