### PR TITLE
fix(lti): add NRPS pagination link headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ----------
 
+11.4.0 - 2026-07-16
+--------------------
+* Add pagination support to the NRPS ``/context_membership`` endpoint, accepting
+  ``limit`` and ``page`` query parameters with RFC 8288 ``Link`` headers for
+  continuation.
+
 11.3.1 - 2026-06-01
 --------------------
 * Fix LTI 1.3 deep linking launches to POST the ``id_token`` to the tool-provided ``redirect_uri``

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '11.3.1'
+__version__ = '11.4.0'

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -960,8 +960,9 @@ class LtiNrpsContextMembershipViewSet(viewsets.ReadOnlyModelViewSet):
             compat.merge_course_forum_roles(course_key, data)
             self.attach_external_user_ids(data)
 
-            # Materialize members preserving dict insertion order.
-            members = list(data.values())
+            # The LMS combines unordered enrollment and role-only querysets, so
+            # dict insertion order can change between paginated requests.
+            members = sorted(data.values(), key=lambda m: m['id'])
             total_count = len(members)
 
             limit_param = self.request.query_params.get('limit')

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -110,6 +110,31 @@ def _format_link_header(url, rel):
     """
     return f'<{url}>; rel="{rel}"'
 
+
+def _parse_positive_int(value, default=None):
+    """
+    Parse *value* (a string or ``None``) as a positive integer.
+
+    Returns *default* if *value* is ``None``, not an integer, or
+    non-positive.
+
+    Args:
+        value: Raw string or ``None``.
+        default: Fallback value (default ``None``).
+
+    Returns:
+        int or *default*.
+    """
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (ValueError, TypeError):
+        return default
+    if parsed <= 0:
+        return default
+    return parsed
+
 log = logging.getLogger(__name__)
 
 
@@ -938,29 +963,17 @@ class LtiNrpsContextMembershipViewSet(viewsets.ReadOnlyModelViewSet):
             members = list(data.values())
             total_count = len(members)
 
-            # --- Manual pagination ---
             limit_param = self.request.query_params.get('limit')
             has_next = False
             page = 1
 
             if limit_param is not None:
-                # Parse limit; must be a positive integer, else skip pagination.
-                try:
-                    limit = int(limit_param)
-                    if limit <= 0:
-                        limit = None
-                except (ValueError, TypeError):
-                    limit = None
-
+                limit = _parse_positive_int(limit_param, default=None)
                 if limit is not None:
-                    # Parse page; must be a positive integer, else default to 1.
-                    try:
-                        page = int(self.request.query_params.get('page', 1))
-                        if page <= 0:
-                            page = 1
-                    except (ValueError, TypeError):
-                        page = 1
-
+                    page = _parse_positive_int(
+                        self.request.query_params.get('page'),
+                        default=1,
+                    )
                     start = (page - 1) * limit
                     end = start + limit
                     members = members[start:end]

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -135,6 +135,7 @@ def _parse_positive_int(value, default=None):
         return default
     return parsed
 
+
 log = logging.getLogger(__name__)
 
 

--- a/lti_consumer/plugin/views.py
+++ b/lti_consumer/plugin/views.py
@@ -69,6 +69,47 @@ from lti_consumer.signals.signals import LTI_1P3_PROCTORING_ASSESSMENT_STARTED
 from lti_consumer.track import track_event
 from lti_consumer.utils import _, get_data_from_cache, get_lti_1p3_context_types_claim, get_lti_api_base
 
+
+def _build_url_with_query(request, query_params):
+    """
+    Build an absolute URL from the request path, merging current query parameters
+    and overriding/removing keys as specified.
+
+    Args:
+        request: DRF request object.
+        query_params: dict of query parameter key/value pairs to set.
+            Keys set to ``None`` are removed from the result.
+
+    Returns:
+        str: Absolute URL with the resulting query parameters.
+    """
+    base_url = request.build_absolute_uri(request.path)
+    # Start from current query params and apply overrides/removals.
+    # Use .dict() (not dict()) to get single values from MultiValueDict.
+    merged = request.query_params.dict()
+    for key, value in query_params.items():
+        if value is None:
+            merged.pop(key, None)
+        else:
+            merged[key] = value
+    if merged:
+        return f"{base_url}?{urllib.parse.urlencode(merged)}"
+    return base_url
+
+
+def _format_link_header(url, rel):
+    """
+    Format an RFC 8288 Link header value.
+
+    Args:
+        url: The target URL.
+        rel: The link relation type (e.g. 'next').
+
+    Returns:
+        str: Formatted Link header value.
+    """
+    return f'<{url}>; rel="{rel}"'
+
 log = logging.getLogger(__name__)
 
 
@@ -871,6 +912,18 @@ class LtiNrpsContextMembershipViewSet(viewsets.ReadOnlyModelViewSet):
         """
         Overrides default list method of ModelViewSet. Calls LMS `get_course_members`
         API and returns result.
+
+        Supports manual pagination via ``limit`` and ``page`` query parameters
+        (per NRPS 2.0 §2.4.2):
+
+        * limit (positive integer): Maximum members per page.  When absent,
+          all members are returned and no pagination Link header is emitted.
+        * page (positive integer, default 1): 1-indexed page number.
+          Only consulted when ``limit`` is present and valid.
+
+        When ``limit`` is present and more members remain after the current
+        page, a ``Link`` header with ``rel="next"`` is included whose URL
+        carries the same ``limit`` and an incremented ``page``.
         """
 
         # get course key
@@ -881,18 +934,59 @@ class LtiNrpsContextMembershipViewSet(viewsets.ReadOnlyModelViewSet):
             compat.merge_course_forum_roles(course_key, data)
             self.attach_external_user_ids(data)
 
+            # Materialize members preserving dict insertion order.
+            members = list(data.values())
+            total_count = len(members)
+
+            # --- Manual pagination ---
+            limit_param = self.request.query_params.get('limit')
+            has_next = False
+            page = 1
+
+            if limit_param is not None:
+                # Parse limit; must be a positive integer, else skip pagination.
+                try:
+                    limit = int(limit_param)
+                    if limit <= 0:
+                        limit = None
+                except (ValueError, TypeError):
+                    limit = None
+
+                if limit is not None:
+                    # Parse page; must be a positive integer, else default to 1.
+                    try:
+                        page = int(self.request.query_params.get('page', 1))
+                        if page <= 0:
+                            page = 1
+                    except (ValueError, TypeError):
+                        page = 1
+
+                    start = (page - 1) * limit
+                    end = start + limit
+                    members = members[start:end]
+                    has_next = end < total_count
+
             # build correct format for the serializer
             result = {
                 'id': self.request.build_absolute_uri(),
                 'context': {
                     'id': course_key
                 },
-                'members': data.values(),
+                'members': members,
             }
 
             # Serialize and return data NRPS reponse.
             serializer = self.get_serializer_class()(result)
-            return Response(serializer.data)
+            response = Response(serializer.data)
+
+            if has_next:
+                next_url = _build_url_with_query(self.request, {
+                    'limit': limit,
+                    'page': page + 1,
+                })
+                response['Link'] = _format_link_header(next_url, 'next')
+
+            return response
 
         except LtiError as ex:
             log.warning("LTI NRPS Error: %s", ex)

--- a/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
@@ -370,3 +370,142 @@ class LtiNrpsContextMembershipViewsetTestCase(LtiNrpsTestCase):
         response = self.client.get(self.context_membership_endpoint)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.data['error'], 'above_response_limit')
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_limit_pagination_returns_bounded_page(self):
+        """
+        Test that when limit is provided, the response contains at most 'limit' members
+        and includes a Link header with rel="next" when more members remain.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+        response = self.client.get(self.context_membership_endpoint, {'limit': 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 2)
+        self.assertTrue(response.has_header('Link'))
+        self.assertIn('rel="next"', response['Link'])
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_limit_pagination_next_url_has_limit_and_page(self):
+        """
+        Test that the Link header's next URL contains the same limit and page=2
+        and preserves unrelated query params.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+        response = self.client.get(
+            self.context_membership_endpoint,
+            {'limit': 2, 'role': 'foo'},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.has_header('Link'))
+
+        link_header = response['Link']
+        parsed_links = self._parse_link_headers(link_header)
+        self.assertIn('next', parsed_links)
+
+        next_url = parsed_links['next']
+        self.assertIn('limit=2', next_url)
+        self.assertIn('page=2', next_url)
+        self.assertIn('role=foo', next_url)
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_limit_pagination_last_page_omits_next(self):
+        """
+        Test that on the last page, no Link header with rel="next" is present.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+        response = self.client.get(self.context_membership_endpoint, {'limit': 2, 'page': 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 2)
+        self.assertFalse(response.has_header('Link'))
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_limit_pagination_single_remaining(self):
+        """
+        Test that when limit=3 and page=2, only 1 member is returned and no next Link.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+        response = self.client.get(self.context_membership_endpoint, {'limit': 3, 'page': 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 1)
+        self.assertFalse(response.has_header('Link'))
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_invalid_limit_returns_all_members(self):
+        """
+        Test that an invalid limit (non-positive or non-integer) returns all members
+        without pagination.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+
+        # Test with limit=0
+        response = self.client.get(self.context_membership_endpoint, {'limit': 0})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 4)
+        self.assertFalse(response.has_header('Link'))
+
+        # Test with negative limit
+        response = self.client.get(self.context_membership_endpoint, {'limit': -5})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 4)
+        self.assertFalse(response.has_header('Link'))
+
+        # Test with non-integer limit
+        response = self.client.get(self.context_membership_endpoint, {'limit': 'abc'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 4)
+        self.assertFalse(response.has_header('Link'))
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    @patch(
+        'lti_consumer.plugin.views.compat.get_course_members',
+        Mock(side_effect=patch_get_memberships({
+            'student': 4
+        })),
+    )
+    def test_invalid_page_defaults_to_one(self):
+        """
+        Test that an invalid page value defaults to page 1.
+        """
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+
+        # Test with page=0
+        response = self.client.get(self.context_membership_endpoint, {'limit': 2, 'page': 0})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 2)
+        self.assertTrue(response.has_header('Link'))
+
+        # Test with non-integer page
+        response = self.client.get(self.context_membership_endpoint, {'limit': 2, 'page': 'abc'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['members']), 2)
+        self.assertTrue(response.has_header('Link'))

--- a/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
+++ b/lti_consumer/tests/unit/plugin/test_views_lti_nrps.py
@@ -16,6 +16,7 @@ from lti_consumer.lti_1p3.constants import (
 )
 from lti_consumer.lti_xblock import LtiConsumerXBlock
 from lti_consumer.models import LtiConfiguration
+from lti_consumer.plugin.views import LtiNrpsContextMembershipViewSet
 from lti_consumer.tests.test_utils import TestBaseWithPatch, make_xblock
 
 
@@ -509,3 +510,40 @@ class LtiNrpsContextMembershipViewsetTestCase(LtiNrpsTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['members']), 2)
         self.assertTrue(response.has_header('Link'))
+
+    @patch('lti_consumer.plugin.views.get_lti_pii_sharing_state_for_course', Mock(return_value=False))
+    def test_pagination_sorts_by_id_for_stable_pages(self):
+        """Test pagination stays stable when member insertion order changes between requests.
+
+        The two page requests return the same members in opposite dictionary orders;
+        sorting by ID should still produce every member exactly once, without gaps or
+        duplicates.
+        """
+        members = [{'id': 2000 + i, 'username': f'user_{2000 + i}', 'roles': ['student']} for i in range(4)]
+        insertion_orders = [members, list(reversed(members))]
+
+        def get_members(_course_key):
+            return {member['id']: member for member in insertion_orders.pop(0)}
+
+        def attach_external_ids(data):
+            for member in data.values():
+                member['external_id'] = str(member['id'])
+
+        self._set_lti_token('https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly')
+
+        with patch('lti_consumer.plugin.views.compat.get_course_members', side_effect=get_members), patch.object(
+            LtiNrpsContextMembershipViewSet,
+            'attach_external_user_ids',
+            side_effect=attach_external_ids,
+        ):
+            page_ids = []
+            for page in (1, 2):
+                response = self.client.get(
+                    self.context_membership_endpoint,
+                    {'limit': 2, 'page': page},
+                )
+                self.assertEqual(response.status_code, 200)
+                page_ids.extend(member['user_id'] for member in response.data['members'])
+
+        self.assertEqual(page_ids, ['2000', '2001', '2002', '2003'])
+        self.assertEqual(len(page_ids), len(set(page_ids)))


### PR DESCRIPTION
## Description

The LTI NRPS Context Membership endpoint (`GET /memberships`) currently returns all course members in a single response.

This PR adds manual pagination following the NRPS v2.0 specification:

- **`limit`** query param — maximum members per page. When absent, all members are returned (preserving backward compatibility).
- **`page`** query param — 1-indexed page number (default 1). Only consulted when `limit` is present and valid.
- **`Link: <url>; rel="next"`** header — emitted when more members remain after the current page. The URL carries the same `limit` and an incremented `page`, and preserves any other query params present on the original request.

Invalid/zero/negative `limit` silently falls back to no pagination. Invalid/zero/negative `page` defaults to page 1.

**Co-authored by:** GPT 5.5

## Related

* https://github.com/openedx/xblock-lti-consumer/issues/669

## Test instructions

### Prerequisites

- Devstack running
- A course with at least a few enrolled users
- An LTI 1.3 block configured with NRPS enabled (`lti_1p3_enable_nrps = True`)

### 1. Get the LTI Configuration ID

Open an LMS Django shell:

```bash
# Inside the lms container or via
tutor dev exec lms bash
```

```python
from lti_consumer.models import LtiConfiguration
from django.contrib.auth.models import User

# List LTI 1.3 configs
for c in LtiConfiguration.objects.filter(version=LtiConfiguration.LTI_1P3)[:10]:
    print(c.id, c.location)
```

Note the `id` of a config whose block has NRPS enabled. We'll call this `<CONFIG_ID>`.

### 2. Create a Bearer Token (dev-only)

In the same shell session:

```python
from lti_consumer.models import LtiConfiguration

config = LtiConfiguration.objects.get(id=<CONFIG_ID>)
consumer = config.get_lti_consumer()

token = consumer.key_handler.encode_and_sign({
    "iss": "https://example.com",
    "scopes": "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
})
print(token)
```

Copy the printed token. We'll call this `<TOKEN>`.

### 3. Test Without Pagination (Baseline)

```bash
curl -s -H "Authorization: Bearer <TOKEN>" \
  "http://localhost:18000/lti_consumer/v1/lti/<CONFIG_ID>/memberships" \
  | python -m json.tool | head -20
```

Expected:

- Status `200`
- All enrolled members returned under `members`
- **No** `Link` header in the response

### 4. Test First Page with `limit`

```bash
curl -s -v -H "Authorization: Bearer <TOKEN>" \
  "http://localhost:18000/lti_consumer/v1/lti/<CONFIG_ID>/memberships?limit=2" \
  2>&1 | tee /tmp/nrps_page1.txt
```

Expected:

- Status `200`
- Exactly 2 members in `members`
- **`Link` header present** with `rel="next"` containing `limit=2&page=2`

### 5. Test Second Page

Parse the `Link` header URL from step 4 and call it:

```bash
curl -s -v -H "Authorization: Bearer <TOKEN>" \
  "http://localhost:18000/lti_consumer/v1/lti/<CONFIG_ID>/memberships?limit=2&page=2" \
  2>&1 | tee /tmp/nrps_page2.txt
```

Expected:

- Status `200`
- Next 2 members (or the remaining members)
- **No** `Link` header if this is the last page

### 6. Test Preserving Unrelated Params

```bash
curl -s -v -H "Authorization: Bearer <TOKEN>" \
  "http://localhost:18000/lti_consumer/v1/lti/<CONFIG_ID>/memberships?limit=2&role=instructor" \
  2>&1 | tee /tmp/nrps_role.txt
```

Expected:

- Status `200`
- `Link` header URL contains `role=instructor` alongside `limit=2&page=2`

### 7. Test Invalid Limit (should return all members)

```bash
curl -s -H "Authorization: Bearer <TOKEN>" \
  "http://localhost:18000/lti_consumer/v1/lti/<CONFIG_ID>/memberships?limit=0" \
  | python -m json.tool | head -10
```

Expected:

- Status `200`
- All members returned
- No `Link` header

### 8. Test Invalid Page (should default to page 1)

```bash
curl -s -H "Authorization: Bearer <TOKEN>" \
  "http://localhost:18000/lti_consumer/v1/lti/<CONFIG_ID>/memberships?limit=2&page=-1" \
  | python -m json.tool
```

Expected:

- Status `200`
- Same result as `limit=2` (page 1)
